### PR TITLE
Add support for Text-to-Speech and HTTP downloaded voice #8

### DIFF
--- a/ChatdollKit/Model/AnimatedVoice.cs
+++ b/ChatdollKit/Model/AnimatedVoice.cs
@@ -17,9 +17,19 @@ namespace ChatdollKit.Model
             Faces = faces ?? new List<FaceExpression>();
         }
 
-        public void AddVoice(string name, float preGap = 0.0f, float postGap = 0.0f)
+        public void AddVoice(string name, float preGap = 0.0f, float postGap = 0.0f, string text = null, string url = null, VoiceSource source = VoiceSource.Local)
         {
-            Voices.Add(new Voice(name, preGap, postGap));
+            Voices.Add(new Voice(name, preGap, postGap, text, url, source));
+        }
+
+        public void AddVoiceWeb(string url, float preGap = 0.0f, float postGap = 0.0f, string name = null, string text = null)
+        {
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, url, VoiceSource.Web));
+        }
+
+        public void AddVoiceTTS(string text, float preGap = 0.0f, float postGap = 0.0f, string name = null)
+        {
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, string.Empty, VoiceSource.TTS));
         }
 
         public void AddAnimation(string name, string layerName = null, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f)

--- a/ChatdollKit/Model/Voice.cs
+++ b/ChatdollKit/Model/Voice.cs
@@ -1,17 +1,28 @@
 ﻿namespace ChatdollKit.Model
 {
+    public enum VoiceSource
+    {
+        Local, Web, TTS
+    }
+
     // Voice
     public class Voice
     {
         public string Name { get; set; }
         public float PreGap { get; set; }
         public float PostGap { get; set; }
+        public string Text { get; set; }
+        public string Url { get; set; }
+        public VoiceSource Source { get; set; }
 
-        public Voice(string name, float preGap, float postGap)
+        public Voice(string name, float preGap, float postGap, string text, string url, VoiceSource source)
         {
             Name = name;
             PreGap = preGap;
             PostGap = postGap;
+            Text = text;
+            Url = url;
+            Source = source;
         }
     }
 }

--- a/ChatdollKit/Model/VoiceRequest.cs
+++ b/ChatdollKit/Model/VoiceRequest.cs
@@ -23,9 +23,19 @@ namespace ChatdollKit.Model
             }
         }
 
-        public void AddVoice(string name, float preGap = 0.0f, float postGap = 0.0f)
+        public void AddVoice(string name, float preGap = 0.0f, float postGap = 0.0f, string text = null, string url = null, VoiceSource source = VoiceSource.Local)
         {
-            Voices.Add(new Voice(name, preGap, postGap));
+            Voices.Add(new Voice(name, preGap, postGap, text, url, source));
+        }
+
+        public void AddVoiceWeb(string url, float preGap = 0.0f, float postGap = 0.0f, string name = null, string text = null)
+        {
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, url, VoiceSource.Web));
+        }
+
+        public void AddVoiceTTS(string text, float preGap = 0.0f, float postGap = 0.0f, string name = null)
+        {
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, string.Empty, VoiceSource.TTS));
         }
     }
 }


### PR DESCRIPTION
Use like below;

```Csharp
var request = new VoiceRequest();
// Local
request.AddVoice("hello");
// Text-to-Speech
request.AddVoiceTTS("This message is generated by Azure");
// HTTP download
request.AddVoiceWeb("https://host/path/to/voice.wav");
```

You can cache the AudioClip to avoid generate or download again by adding its name.

```Csharp
// Text-to-Speech
request.AddVoiceTTS("This message is generated by Azure", name: "ttsvoice");
// HTTP download
request.AddVoiceWeb("https://host/path/to/voice.wav", name: "webvoice");
```

todo: Preload while speaking previous sentence