### PR TITLE
Fix bug and installation steps to enable SpeechRecognizer

### DIFF
--- a/ChatdollKit.Extension/GoogleCloudSpeechRequestProvider.cs
+++ b/ChatdollKit.Extension/GoogleCloudSpeechRequestProvider.cs
@@ -133,6 +133,7 @@ namespace ChatdollKit.Extension
                     if (Time.time - startTime > Timeout)
                     {
                         Debug.Log($"Recording timeout");
+                        speechRecognition.StopRecord();
                         return string.Empty;
                     }
                     await Task.Delay(50);

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,10 +25,9 @@ Watch this 2 minutes video to learn how ChatdollKit works and the way to use qui
 
 お好みの3Dモデルをシーンに配置してください。シェーダーやダイナミックボーンなど必要に応じてセットアップしておいてください。なおこの手順で使っているモデルはシグネットちゃんです。とてもかわいいですね。 https://booth.pm/ja/items/1870320
 
-モデル自体の設定が完了したら、リップシンクの設定もしておきます。モデルのオブジェクトまたは適当な場所に追加したオブジェクトに、インスペクターから以下3つのコンポーネントを追加してください。
+モデル自体の設定が完了したら、リップシンクの設定もしておきます。モデルのオブジェクトまたは適当な場所に追加したオブジェクトに、インスペクターから以下2つのコンポーネントを追加してください。
 
 - OVR Lip Sync Context Morph Target
-- OVR Lip Sync Mic Input
 - OVR Lip Sync Context
 
 表情関連のシェイプキーを`OVR Lip Sync Context Morph Target`の`Skinned Mesh Renderer`に設定し、`OVR Lip Sync Context`の`Audio Loopback`のチェックをオンにすれば設定完了です。これによって3Dモデルにおしゃべりをさせると発話内容に応じて口が動くようになります。

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Clone or download this repository and put `ChatdollKit` directory into your Unit
 Add 3D model to the scene and adjust as you like. Install required resources for the 3D model like shaders and Dynamic Bone at this time.
 In this README, I use Cygnet-chan that we can perchase at Booth. https://booth.pm/ja/items/1870320
 
-After adjustment, add the LipSync components using inspector.
+After adjustment, add following LipSync components using inspector.
 
 - OVR Lip Sync Context Morph Target
-- OVR Lip Sync Mic Input
 - OVR Lip Sync Context
 
 Then set the object that has the shapekeys for face expressions to `Skinned Mesh Renderer` in `OVR Lip Sync Context Morph Target` and turn on `Audio Loopback` in `OVR Lip Sync Context`.


### PR DESCRIPTION
- Fixed: GCSR Request Provider doesn't stop recording when recognition timeout.
- Fixed: LipSync handles the microphone instead of RequestProvider because of the wrong setting up steps in README.md.