### PR TITLE
Add examples for translation using Azure and Google

### DIFF
--- a/ChatdollKit.Extension/AzureTranslator.cs
+++ b/ChatdollKit.Extension/AzureTranslator.cs
@@ -1,0 +1,73 @@
+﻿using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+using Newtonsoft.Json;
+using ChatdollKit.Network;
+
+
+namespace ChatdollKit.Extension
+{
+    public class AzureTranslator
+    {
+        public string ApiKey { get; set; }
+
+        public AzureTranslator(string apiKey)
+        {
+            ApiKey = apiKey;
+        }
+
+        // Translate
+        public async Task<string> TranslateAsync(string text, string language = "en")
+        {
+            // Compose url
+            var url = $"https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&to={language}";
+
+            using (var www = UnityWebRequest.Post(url, string.Empty))
+            {
+                www.timeout = 10;
+
+                // Set headers
+                www.SetRequestHeader("Ocp-Apim-Subscription-Key", ApiKey);
+                www.SetRequestHeader("Content-Type", "application/json; charset=UTF-8");
+
+                // Set data
+                var data = new List<AzureTranslationText>() { new AzureTranslationText(text) };
+                www.uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data)));
+
+                // Send request
+                await www.SendWebRequest();
+
+                // Handle response
+                if (www.isNetworkError || www.isHttpError)
+                {
+                    Debug.LogError($"Error occured while processing text-to-speech voice: {www.error}");
+                }
+                else if (www.isDone)
+                {
+                    var responseString = DownloadHandlerBuffer.GetContent(www);
+                    var translationResponse = JsonConvert.DeserializeObject<List<AzureTranslationResponse>>(responseString);
+                    var translatedText = translationResponse[0].Translations[0].Text;
+                    return translatedText;
+                }
+            }
+            return null;
+        }
+    }
+
+    class AzureTranslationResponse
+    {
+        public List<AzureTranslationText> Translations { get; set; }
+    }
+
+    class AzureTranslationText
+    {
+        public string Text { get; set; }
+
+        public AzureTranslationText(string text)
+        {
+            Text = text;
+        }
+    }
+}

--- a/ChatdollKit.Extension/GoogleTranslator.cs
+++ b/ChatdollKit.Extension/GoogleTranslator.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using ChatdollKit.Network;
+using Newtonsoft.Json;
+using UnityEngine;
+using UnityEngine.Networking;
+
+
+namespace ChatdollKit.Extension
+{
+    public class GoogleTranslator
+    {
+        public string ApiKey { get; set; }
+
+        public GoogleTranslator(string apiKey)
+        {
+            ApiKey = apiKey;
+        }
+
+        // Translate
+        public async Task<string> TranslateAsync(string text, string language = "en")
+        {
+            // Compose url
+            var url = $"https://translation.googleapis.com/language/translate/v2";
+
+            // Set data
+            var data = new WWWForm();
+            data.AddField("key", ApiKey);
+            data.AddField("q", text);
+            data.AddField("target", language);
+            data.AddField("source", "ja");
+            data.AddField("model", "nmt");
+
+            using (var www = UnityWebRequest.Post(url, data))
+            {
+                www.timeout = 10;
+
+                // Send request
+                await www.SendWebRequest();
+
+                // Handle response
+                if (www.isNetworkError || www.isHttpError)
+                {
+                    Debug.LogError($"Error occured while processing text-to-speech voice: {www.error}");
+                }
+                else if (www.isDone)
+                {
+                    var responseString = DownloadHandlerBuffer.GetContent(www);
+                    var translationResponse = JsonConvert.DeserializeObject<GoogleTranslationResponse>(responseString);
+                    var translatedText = translationResponse.Data.Translations[0].TranslatedText;
+                    return translatedText;
+                }
+            }
+            return null;
+        }
+    }
+
+    class GoogleTranslationResponse
+    {
+        public GoogleTranslationData Data { get; set; }
+    }
+
+    class GoogleTranslationData
+    {
+        public List<GoogleTranslationText> Translations { get; set; }
+    }
+
+    class GoogleTranslationText
+    {
+        public string TranslatedText { get; set; }
+    }
+}


### PR DESCRIPTION
Create instance of Azure/GoogleTranslator with API Key and call `TranslateAsync` to translate text. The default target language is English.

```Csharp
var azureTranslator = new AzureTranslator("YOUR_SUBSCRIPTION_KEY");
var translatedText = await azureTranslator.TranslateAsync(request.Text);
```

or

```CSharp
var googleTranslator = new GoogleTranslator("YOUR_API_KEY");
var translatedText = await googleTranslator.TranslateAsync(request.Text);
```