### PR TITLE
Add history recorder to ModelController for debugging and testing

### DIFF
--- a/ChatdollKit/Model/ActionHistoryRecorder.cs
+++ b/ChatdollKit/Model/ActionHistoryRecorder.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace ChatdollKit.Model
+{
+    public class ActionHistoryRecorder
+    {
+        public bool Enabled { get; set; }
+        public List<ActionHistory> Histories { get; set; }
+        public Action<ActionHistory> SendHistory { get; set; }
+
+        public ActionHistoryRecorder(bool enabled = false, Action<ActionHistory> sendHistoryFunc = null)
+        {
+            Enabled = enabled;
+            Histories = new List<ActionHistory>();
+            SendHistory = sendHistoryFunc;
+        }
+
+        public string Add(object action)
+        {
+            if (!Enabled) return string.Empty;
+
+            var history = new ActionHistory(action);
+            Histories.Add(history);
+            SendHistory?.Invoke(history);
+            return history.Id;
+        }
+
+        public void Add(string id, string description)
+        {
+            if (!Enabled) return;
+
+            var history = new ActionHistory()
+            {
+                Id = id,
+                Description = description,
+                Timestamp = DateTime.UtcNow
+            };
+            var originalAction = Histories.Where(j => j.Id == id).FirstOrDefault();
+            if (originalAction != null)
+            {
+                history.ActionType = originalAction.ActionType;
+                Histories.Add(history);
+                SendHistory?.Invoke(history);
+            }
+        }
+
+    }
+
+    public class ActionHistory
+    {
+        public string Id { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string ActionType { get; set; }
+        public object ActionElement { get; set; }
+        public string Description { get; set; }
+
+        public ActionHistory()
+        {
+
+        }
+
+        public ActionHistory(object action, string description = null)
+        {
+            Id = Guid.NewGuid().ToString();
+            Timestamp = DateTime.UtcNow;
+            Description = description;
+            ActionElement = action;
+
+            if (action is Voice)
+            {
+                ActionType = "voice";
+            }
+            else if (action is Animation)
+            {
+                ActionType = "animation";
+            }
+            else if (action is FaceExpression)
+            {
+                ActionType = "face";
+            }
+            else if (action is string)
+            {
+                ActionType = "message";
+            }
+            else
+            {
+                ActionType = "other";
+            }
+        }
+    }
+}

--- a/ChatdollKit/Model/AnimatedVoice.cs
+++ b/ChatdollKit/Model/AnimatedVoice.cs
@@ -32,18 +32,18 @@ namespace ChatdollKit.Model
             Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, string.Empty, ttsOptions, VoiceSource.TTS));
         }
 
-        public void AddAnimation(string name, string layerName = null, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f)
+        public void AddAnimation(string name, string layerName = null, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f, string description = null)
         {
             if (!Animations.ContainsKey(layerName))
             {
                 Animations.Add(layerName, new List<Animation>());
             }
-            Animations[layerName].Add(new Animation(name, layerName, duration, fadeLength, weight, preGap));
+            Animations[layerName].Add(new Animation(name, layerName, duration, fadeLength, weight, preGap, description));
         }
 
-        public void AddFace(string name, float duration = 0.0f)
+        public void AddFace(string name, float duration = 0.0f, string description = null)
         {
-            Faces.Add(new FaceExpression(name, duration));
+            Faces.Add(new FaceExpression(name, duration, description));
         }
     }
 }

--- a/ChatdollKit/Model/AnimatedVoiceRequest.cs
+++ b/ChatdollKit/Model/AnimatedVoiceRequest.cs
@@ -28,17 +28,17 @@ namespace ChatdollKit.Model
             BaseLayerName = baseLayerName ?? string.Empty;
         }
 
-        public void AddAnimatedVoice(string voiceName, string animationName, string faceName = null, float voicePreGap = 0.0f, float voicePostGap = 0.0f, float animationDuration = 0.0f, float animationFadeLength = -1.0f, float animationWeight = 1.0f, float animationPreGap = 0.0f, float faceDuration = 0.0f, bool asNewFrame = false)
+        public void AddAnimatedVoice(string voiceName, string animationName, string faceName = null, float voicePreGap = 0.0f, float voicePostGap = 0.0f, float animationDuration = 0.0f, float animationFadeLength = -1.0f, float animationWeight = 1.0f, float animationPreGap = 0.0f, float faceDuration = 0.0f, string description = null, bool asNewFrame = false)
         {
             if (asNewFrame || AnimatedVoices.Count == 0)
             {
                 CreateNewFrame();
             }
             AddVoice(voiceName, voicePreGap, voicePostGap);
-            AddAnimation(animationName, animationDuration, animationFadeLength, animationWeight, animationPreGap);
+            AddAnimation(animationName, animationDuration, animationFadeLength, animationWeight, animationPreGap, description);
             if (faceName != null)
             {
-                AddFace(faceName, faceDuration);
+                AddFace(faceName, faceDuration, description);
             }
         }
 
@@ -69,27 +69,27 @@ namespace ChatdollKit.Model
             AnimatedVoices.Last().AddVoiceTTS(text, preGap, postGap, name, ttsOptions);
         }
 
-        public void AddAnimation(string name, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f, bool asNewFrame = false)
+        public void AddAnimation(string name, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f, string description = null, bool asNewFrame = false)
         {
-            AddAnimation(name, BaseLayerName, duration, fadeLength, weight, preGap, asNewFrame);
+            AddAnimation(name, BaseLayerName, duration, fadeLength, weight, preGap, description, asNewFrame);
         }
 
-        public void AddAnimation(string name, string layerName, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f, bool asNewFrame = false)
+        public void AddAnimation(string name, string layerName, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f, string description = null, bool asNewFrame = false)
         {
             if (asNewFrame || AnimatedVoices.Count == 0)
             {
                 CreateNewFrame();
             }
-            AnimatedVoices.Last().AddAnimation(name, layerName, duration, fadeLength, weight, preGap);
+            AnimatedVoices.Last().AddAnimation(name, layerName, duration, fadeLength, weight, preGap, description);
         }
 
-        public void AddFace(string name, float duration = 0.0f, bool asNewFrame = false)
+        public void AddFace(string name, float duration = 0.0f, string description = null, bool asNewFrame = false)
         {
             if (asNewFrame || AnimatedVoices.Count == 0)
             {
                 CreateNewFrame();
             }
-            AnimatedVoices.Last().AddFace(name, duration);
+            AnimatedVoices.Last().AddFace(name, duration, description);
         }
 
         public int CreateNewFrame()

--- a/ChatdollKit/Model/Animation.cs
+++ b/ChatdollKit/Model/Animation.cs
@@ -8,8 +8,9 @@
         public float FadeLength { get; set; }
         public float Weight { get; set; }
         public float PreGap { get; set; }
+        public string Description { get; set; }
 
-        public Animation(string name, string layerName, float duration, float fadeLength, float weight, float preGap)
+        public Animation(string name, string layerName, float duration, float fadeLength, float weight, float preGap, string description)
         {
             Name = name;
             LayerName = layerName;
@@ -17,6 +18,7 @@
             FadeLength = fadeLength;
             Weight = weight;
             PreGap = preGap;
+            Description = description;
         }
 
         public float Length

--- a/ChatdollKit/Model/AnimationRequest.cs
+++ b/ChatdollKit/Model/AnimationRequest.cs
@@ -69,13 +69,13 @@ namespace ChatdollKit.Model
             AddAnimation(name, BaseLayerName, duration, fadeLength, weight, preGap);
         }
 
-        public void AddAnimation(string name, string layerName, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f)
+        public void AddAnimation(string name, string layerName, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f, string description = null)
         {
             if (!Animations.ContainsKey(layerName))
             {
                 Animations.Add(layerName, new List<Animation>());
             }
-            Animations[layerName].Add(new Animation(name, layerName, duration, fadeLength, weight, preGap));
+            Animations[layerName].Add(new Animation(name, layerName, duration, fadeLength, weight, preGap, description));
         }
     }
 }

--- a/ChatdollKit/Model/FaceExpression.cs
+++ b/ChatdollKit/Model/FaceExpression.cs
@@ -5,11 +5,13 @@
     {
         public string Name { get; set; }
         public float Duration { get; set; }
+        public string Description { get; set; }
 
-        public FaceExpression(string name, float duration)
+        public FaceExpression(string name, float duration, string description)
         {
             Name = name;
             Duration = duration;
+            Description = description;
         }
     }
 }

--- a/ChatdollKit/Model/FaceRequest.cs
+++ b/ChatdollKit/Model/FaceRequest.cs
@@ -15,9 +15,9 @@ namespace ChatdollKit.Model
             DefaultOnEnd = defaultOnEnd;
         }
 
-        public void AddFace(string name, float duration = 0.0f)
+        public void AddFace(string name, float duration = 0.0f, string description = null)
         {
-            Faces.Add(new FaceExpression(name, duration));
+            Faces.Add(new FaceExpression(name, duration, description));
         }
     }
 }


### PR DESCRIPTION
# Usage

Set instance of ActionHistoryRecorder to `ModelController` before its `Start()` is called.

```Csharp
chatdoll.ModelController.History = new ActionHistoryRecorder(true);
```

# Arguments
- bool enabled: Set `true` to enable the history recorder. Default is false.
- Action<ActionHistory> sendHistory: Method to write or send history anywhere you like. This is called when each history added.