### PR TITLE
Fix bug in context status update

### DIFF
--- a/ChatdollKit/Scripts/Chatdoll.cs
+++ b/ChatdollKit/Scripts/Chatdoll.cs
@@ -162,13 +162,9 @@ namespace ChatdollKit
 
                 try
                 {
-                    if (!request.IsSet()) {
-                        // Just exit loop without clearing context when request is not set
-                        return;
-                    }
-                    else if (request.IsCanceled)
+                    if (!request.IsSet() || request.IsCanceled)
                     {
-                        // Clear context data and topic when canceled
+                        // Clear context when request is not set or canceled
                         context.Clear();
                         await ContextStore.SaveContextAsync(context);
                         return;


### PR DESCRIPTION
Fix the bug that chat process exits without saving context and updating these properties when request is not set:

- context.IsNew
- context.Topic.IsNew
- context.Topic.ContinueTopic