### PR TITLE
Improve usage of Web/TTS VoiceLoader

### DIFF
--- a/ChatdollKit/Scripts/Chatdoll.cs
+++ b/ChatdollKit/Scripts/Chatdoll.cs
@@ -98,9 +98,18 @@ namespace ChatdollKit
 
             // ModelController
             ModelController = gameObject.GetComponent<ModelController>();
-            if (ModelController == null)
+
+            // Web and TTS voice loaders
+            foreach (var loader in gameObject.GetComponents<IVoiceLoader>())
             {
-                Debug.LogError("ModelController is missing");
+                if (loader.Type == VoiceLoaderType.Web)
+                {
+                    ModelController.VoiceDownloadFunc = loader.GetAudioClipAsync;
+                }
+                else if (loader.Type == VoiceLoaderType.TTS)
+                {
+                    ModelController.RegisterTTSFunction(loader.Name, loader.GetAudioClipAsync, loader.IsDefault);
+                }
             }
         }
 

--- a/ChatdollKit/Scripts/Model/IVoiceLoader.cs
+++ b/ChatdollKit/Scripts/Model/IVoiceLoader.cs
@@ -3,8 +3,13 @@ using UnityEngine;
 
 namespace ChatdollKit.Model
 {
+    public enum VoiceLoaderType { Web, TTS };
+
     public interface IVoiceLoader
     {
+        VoiceLoaderType Type { get; }
+        string Name { get; }
+        bool IsDefault { get; set; }
         Task<AudioClip> GetAudioClipAsync(Voice voice);
         bool HasCache(Voice voice);
         bool IsLoading(Voice voice);

--- a/ChatdollKit/Scripts/Model/ModelController.cs
+++ b/ChatdollKit/Scripts/Model/ModelController.cs
@@ -282,12 +282,26 @@ namespace ChatdollKit.Model
                     AudioClip clip = null;
                     if (v.Source == VoiceSource.Web)
                     {
-                        clip = await VoiceDownloadFunc?.Invoke(v);
+                        if (VoiceDownloadFunc != null)
+                        {
+                            clip = await VoiceDownloadFunc(v);
+                        }
+                        else
+                        {
+                            Debug.LogError("Voice download function not found");
+                        }
                     }
                     else if (v.Source == VoiceSource.TTS)
                     {
                         var ttsFunc = GetTTSFunction(v.GetTTSFunctionName());
-                        clip = await ttsFunc?.Invoke(v);
+                        if (ttsFunc != null)
+                        {
+                            clip = await ttsFunc(v);
+                        }
+                        else
+                        {
+                            Debug.LogError($"TTS function not found: {v.GetTTSFunctionName()}");
+                        }
                     }
 
                     if (clip != null)
@@ -334,7 +348,8 @@ namespace ChatdollKit.Model
                     }
                     else if (voice.Source == VoiceSource.TTS)
                     {
-                        TextToSpeechFunc?.Invoke(voice);
+                        var ttsFunc = GetTTSFunction(voice.GetTTSFunctionName());
+                        ttsFunc?.Invoke(voice);
                     }
                 }
             }

--- a/ChatdollKit/Scripts/Model/WebVoiceLoader.cs
+++ b/ChatdollKit/Scripts/Model/WebVoiceLoader.cs
@@ -8,12 +8,7 @@ namespace ChatdollKit.Model
 {
     public class WebVoiceLoader : WebVoiceLoaderBase
     {
-        public AudioType AudioType { get; set; }
-
-        public WebVoiceLoader(AudioType audioType = AudioType.WAV)
-        {
-            AudioType = audioType;
-        }
+        public AudioType AudioType = AudioType.WAV;
 
         protected override async Task<AudioClip> DownloadAudioClipAsync(Voice voice)
         {

--- a/ChatdollKit/Scripts/Model/WebVoiceLoaderBase.cs
+++ b/ChatdollKit/Scripts/Model/WebVoiceLoaderBase.cs
@@ -7,8 +7,12 @@ using ChatdollKit.Network;
 
 namespace ChatdollKit.Model
 {
-    public class WebVoiceLoaderBase : IVoiceLoader
+    public class WebVoiceLoaderBase : MonoBehaviour, IVoiceLoader
     {
+        public virtual VoiceLoaderType Type { get; } = VoiceLoaderType.Web;
+        public virtual string Name { get; } = string.Empty;
+        public virtual bool IsDefault { get; set; } = false;
+
         protected Dictionary<string, AudioClip> audioCache { get; set; } = new Dictionary<string, AudioClip>();
         protected Dictionary<string, Task<AudioClip>> audioDownloadTasks { get; set; } = new Dictionary<string, Task<AudioClip>>();
 

--- a/Extension/AzureTTSLoader.cs
+++ b/Extension/AzureTTSLoader.cs
@@ -9,22 +9,34 @@ namespace ChatdollKit.Extension
 {
     public class AzureTTSLoader : WebVoiceLoaderBase
     {
-        public string ApiKey { get; set; }
-        public string Region { get; set; }
-        public string Language { get; set; }
-        public string Gender { get; set; }
-        public string SpeakerName { get; set; }
-        public AudioType AudioType { get; set; }
-
-        public AzureTTSLoader(string apiKey, string region = "japanwest", string language = "ja-JP", string gender = "Female", string speakerName = "ja-JP-HarukaRUS", AudioType audioType = AudioType.WAV)
+        public override VoiceLoaderType Type { get; } = VoiceLoaderType.TTS;
+        public string _Name = "Azure";
+        public override string Name
         {
-            ApiKey = apiKey;
-            Region = region;
-            Language = language;
-            Gender = gender;
-            SpeakerName = speakerName;
-            AudioType = audioType;
+            get
+            {
+                return _Name;
+            }
         }
+        public bool _IsDefault = false;
+        public override bool IsDefault
+        {
+            get
+            {
+                return _IsDefault;
+            }
+            set
+            {
+                _IsDefault = value;
+            }
+        }
+
+        public string ApiKey;
+        public string Region = "japanwest";
+        public string Language = "ja-JP";
+        public string Gender = "Female";
+        public string SpeakerName = "ja-JP-HarukaRUS";
+        public AudioType AudioType = AudioType.WAV;
 
         protected override async Task<AudioClip> DownloadAudioClipAsync(Voice voice)
         {

--- a/Extension/VoiceroidTTSLoader.cs
+++ b/Extension/VoiceroidTTSLoader.cs
@@ -11,14 +11,29 @@ namespace ChatdollKit.Extension
 {
     public class VoiceroidTTSLoader : WebVoiceLoaderBase
     {
-        public string EndpointUrl { get; set; }
-        public AudioType AudioType { get; set; }
-
-        public VoiceroidTTSLoader(string endpointUrl, AudioType audioType = AudioType.WAV)
+        public override VoiceLoaderType Type { get; } = VoiceLoaderType.TTS;
+        public string _Name = "Voiceroid";
+        public override string Name
         {
-            EndpointUrl = endpointUrl;
-            AudioType = audioType;
+            get
+            {
+                return _Name;
+            }
         }
+        public bool _IsDefault = false;
+        public override bool IsDefault
+        {
+            get
+            {
+                return _IsDefault;
+            }
+            set
+            {
+                _IsDefault = value;
+            }
+        }
+        public string EndpointUrl;
+        public AudioType AudioType = AudioType.WAV;
 
         // Get audio clip from Voiceroid Daemon
         // https://github.com/Nkyoku/voiceroid_daemon


### PR DESCRIPTION
- Change the way to initialize and register Web/TTS VoiceLoaders
- Fix bug that TTSpeech engine is not selected properly in prefetching

You don't need to create instances of VoiceLoaders any more. Just append them to 3D model and configure it on inspector.

Note: Set true to `IsDefault` to use the loader as the Default TTS voice loader.