### PR TITLE
Add default Start/Finish listening action with SimpleMessageWindow

### DIFF
--- a/ChatdollKit/Scripts/Dialog/SimpleMessageWindow.cs
+++ b/ChatdollKit/Scripts/Dialog/SimpleMessageWindow.cs
@@ -62,8 +62,11 @@ namespace ChatdollKit.Dialog
             }
             finally
             {
-                Hide();
-                MessageText.text = "";
+                if (!token.IsCancellationRequested)
+                {
+                    Hide();
+                    MessageText.text = "";
+                }
             }
         }
 


### PR DESCRIPTION
Message window will be automatically shown by setting `SimpleMessageWindow` to `MessageWindow` on inspector of subclasses of `VoiceRequestProviderBase`.
Of course you can also fully customize `OnStartListening` and `OnFinishListening` as ever.