### PR TITLE
Set BlinkBlendShapeName automatically

### DIFF
--- a/ChatdollKit/Editor/FaceClipEditor.cs
+++ b/ChatdollKit/Editor/FaceClipEditor.cs
@@ -242,6 +242,9 @@ public class FaceClipEditor : Editor
 
         // Set audio source
         modelController.AudioSource = lipSyncObject.GetComponent<AudioSource>();
+
+        // Set blink target
+        modelController.BlinkBlendShapeName = GetBlinkTargetName(modelController.SkinnedMeshRenderer);
     }
 
     // Setup ModelController
@@ -462,6 +465,24 @@ public class FaceClipEditor : Editor
         context.audioLoopback = true;
 
         return morphTarget.gameObject;
+    }
+
+    private static string GetBlinkTargetName(SkinnedMeshRenderer skinnedMeshRenderer)
+    {
+        var mesh = skinnedMeshRenderer.sharedMesh;
+        for (var i = 0; i < mesh.blendShapeCount; i++)
+        {
+            var shapeName = mesh.GetBlendShapeName(i).ToLower();
+            if (!shapeName.Contains("left") && !shapeName.Contains("right"))
+            {
+                if (shapeName.Contains("blink") || (shapeName.Contains("eye") && shapeName.Contains("close")))
+                {
+                    return shapeName;
+                }
+            }
+        }
+
+        return string.Empty;
     }
 
     class VisemeTarget


### PR DESCRIPTION
Set the name of ShapeKey to `BlinkBlendShapeName` if it contains "blink" or contains "eye" and "close", and doesn't contain both "left" and "right".