### PR TITLE
Start WakeWordListener without implementing OnWakeAsync

### DIFF
--- a/ChatdollKit/Scripts/IO/WakeWordListenerBase.cs
+++ b/ChatdollKit/Scripts/IO/WakeWordListenerBase.cs
@@ -73,7 +73,9 @@ namespace ChatdollKit.IO
                 if (OnWakeAsync == null)
                 {
                     Debug.LogError("OnWakeAsync must be set");
-                    return;
+#pragma warning disable CS1998
+                    OnWakeAsync = async () => { Debug.LogWarning("Nothing is invoked by wakeword. Set Func to OnWakeAsync."); };
+#pragma warning restore CS1998
                 }
 
                 cancellationTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
This is an improvement for developers experience. Developers can try WWListener by just attaching it (and set APIkey) to the 3D model.