### PR TITLE
Enable to prefetch and cache TTS/Web voice by default #50 #83

### DIFF
--- a/ChatdollKit/Scripts/Model/AnimatedVoice.cs
+++ b/ChatdollKit/Scripts/Model/AnimatedVoice.cs
@@ -19,17 +19,17 @@ namespace ChatdollKit.Model
 
         public void AddVoice(string name, float preGap = 0.0f, float postGap = 0.0f, string text = null, string url = null, TTSConfiguration ttsConfig = null, VoiceSource source = VoiceSource.Local)
         {
-            Voices.Add(new Voice(name, preGap, postGap, text, url, ttsConfig, source));
+            Voices.Add(new Voice(name, preGap, postGap, text, url, ttsConfig, source, false));
         }
 
-        public void AddVoiceWeb(string url, float preGap = 0.0f, float postGap = 0.0f, string name = null, string text = null)
+        public void AddVoiceWeb(string url, float preGap = 0.0f, float postGap = 0.0f, string name = null, string text = null, bool useCache = true)
         {
-            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, url, null, VoiceSource.Web));
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, url, null, VoiceSource.Web, useCache));
         }
 
-        public void AddVoiceTTS(string text, float preGap = 0.0f, float postGap = 0.0f, string name = null, TTSConfiguration ttsConfig = null)
+        public void AddVoiceTTS(string text, float preGap = 0.0f, float postGap = 0.0f, string name = null, TTSConfiguration ttsConfig = null, bool useCache = true)
         {
-            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, string.Empty, ttsConfig, VoiceSource.TTS));
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, string.Empty, ttsConfig, VoiceSource.TTS, useCache));
         }
 
         public void AddAnimation(string name, string layerName = null, float duration = 0.0f, float fadeLength = -1.0f, float weight = 1.0f, float preGap = 0.0f, string description = null)

--- a/ChatdollKit/Scripts/Model/ModelController.cs
+++ b/ChatdollKit/Scripts/Model/ModelController.cs
@@ -383,17 +383,14 @@ namespace ChatdollKit.Model
         {
             foreach (var voice in voices)
             {
-                if (!string.IsNullOrEmpty(voice.Name))
+                if (voice.Source == VoiceSource.Web)
                 {
-                    if (voice.Source == VoiceSource.Web)
-                    {
-                        VoiceDownloadFunc?.Invoke(voice);
-                    }
-                    else if (voice.Source == VoiceSource.TTS)
-                    {
-                        var ttsFunc = GetTTSFunction(voice.GetTTSFunctionName());
-                        ttsFunc?.Invoke(voice);
-                    }
+                    VoiceDownloadFunc?.Invoke(voice);
+                }
+                else if (voice.Source == VoiceSource.TTS)
+                {
+                    var ttsFunc = GetTTSFunction(voice.GetTTSFunctionName());
+                    ttsFunc?.Invoke(voice);
                 }
             }
         }

--- a/ChatdollKit/Scripts/Model/Voice.cs
+++ b/ChatdollKit/Scripts/Model/Voice.cs
@@ -17,8 +17,16 @@ namespace ChatdollKit.Model
         public string Url { get; set; }
         public TTSConfiguration TTSConfig { get; set; }
         public VoiceSource Source { get; set; }
+        public bool UseCache { get; set; }
+        public string CacheKey
+        {
+            get
+            {
+                return Source == VoiceSource.Web ? Url : Text;
+            }
+        }
 
-        public Voice(string name, float preGap, float postGap, string text, string url, TTSConfiguration ttsConfig, VoiceSource source)
+        public Voice(string name, float preGap, float postGap, string text, string url, TTSConfiguration ttsConfig, VoiceSource source, bool useCache)
         {
             Name = name;
             PreGap = preGap;
@@ -27,6 +35,7 @@ namespace ChatdollKit.Model
             Url = url;
             TTSConfig = ttsConfig;
             Source = source;
+            UseCache = useCache;
         }
 
         public object GetTTSParam(string key)

--- a/ChatdollKit/Scripts/Model/VoiceRequest.cs
+++ b/ChatdollKit/Scripts/Model/VoiceRequest.cs
@@ -25,17 +25,17 @@ namespace ChatdollKit.Model
 
         public void AddVoice(string name, float preGap = 0.0f, float postGap = 0.0f, string text = null, string url = null, TTSConfiguration ttsConfig = null, VoiceSource source = VoiceSource.Local)
         {
-            Voices.Add(new Voice(name, preGap, postGap, text, url, ttsConfig, source));
+            Voices.Add(new Voice(name, preGap, postGap, text, url, ttsConfig, source, false));
         }
 
-        public void AddVoiceWeb(string url, float preGap = 0.0f, float postGap = 0.0f, string name = null, string text = null)
+        public void AddVoiceWeb(string url, float preGap = 0.0f, float postGap = 0.0f, string name = null, string text = null, bool useCache = true)
         {
-            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, url, null, VoiceSource.Web));
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, url, null, VoiceSource.Web, useCache));
         }
 
-        public void AddVoiceTTS(string text, float preGap = 0.0f, float postGap = 0.0f, string name = null, TTSConfiguration ttsConfig = null)
+        public void AddVoiceTTS(string text, float preGap = 0.0f, float postGap = 0.0f, string name = null, TTSConfiguration ttsConfig = null, bool useCache = true)
         {
-            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, string.Empty, ttsConfig, VoiceSource.TTS));
+            Voices.Add(new Voice(name ?? string.Empty, preGap, postGap, text, string.Empty, ttsConfig, VoiceSource.TTS, useCache));
         }
     }
 }

--- a/ChatdollKit/Scripts/Model/WebVoiceLoader.cs
+++ b/ChatdollKit/Scripts/Model/WebVoiceLoader.cs
@@ -24,13 +24,10 @@ namespace ChatdollKit.Model
                 else if (www.isDone)
                 {
                     var clip = DownloadHandlerAudioClip.GetContent(www);
-
-                    if (!string.IsNullOrEmpty(voice.Name) && clip != null)
+                    if (clip != null)
                     {
-                        // Cache if name is set
-                        audioCache[voice.Name] = clip;
+                        audioCache[voice.CacheKey] = clip;
                     }
-
                     return clip;
                 }
             }

--- a/ChatdollKit/Scripts/Model/WebVoiceLoaderBase.cs
+++ b/ChatdollKit/Scripts/Model/WebVoiceLoaderBase.cs
@@ -20,17 +20,22 @@ namespace ChatdollKit.Model
         {
             if (IsLoading(voice))
             {
-                await audioDownloadTasks[voice.Name];
+                await audioDownloadTasks[voice.CacheKey];
             }
 
             if (HasCache(voice))
             {
-                return audioCache[voice.Name];
+                var cachedClip = audioCache[voice.CacheKey];
+                if (!voice.UseCache)
+                {
+                    audioCache.Remove(voice.CacheKey);
+                }
+                return cachedClip;
             }
 
-            audioDownloadTasks[voice.Name] = DownloadAudioClipAsync(voice);
-            var clip = await audioDownloadTasks[voice.Name];
-            audioDownloadTasks.Remove(voice.Name);
+            audioDownloadTasks[voice.CacheKey] = DownloadAudioClipAsync(voice);
+            var clip = await audioDownloadTasks[voice.CacheKey];
+            audioDownloadTasks.Remove(voice.CacheKey);
             return clip;
         }
 
@@ -43,15 +48,14 @@ namespace ChatdollKit.Model
 
         public bool HasCache(Voice voice)
         {
-            // Return true when name is set and it's cached
-            return !string.IsNullOrEmpty(voice.Name) && audioCache.ContainsKey(voice.Name);
+            return audioCache.ContainsKey(voice.CacheKey);
         }
 
         public bool IsLoading(Voice voice)
         {
-            if (audioDownloadTasks.ContainsKey(voice.Name))
+            if (audioDownloadTasks.ContainsKey(voice.CacheKey))
             {
-                var task = audioDownloadTasks[voice.Name];
+                var task = audioDownloadTasks[voice.CacheKey];
                 if (task.Status < TaskStatus.RanToCompletion)
                 {
                     return true;

--- a/Extension/VoiceroidTTSLoader.cs
+++ b/Extension/VoiceroidTTSLoader.cs
@@ -72,10 +72,9 @@ namespace ChatdollKit.Extension
                 else if (www.isDone)
                 {
                     var clip = DownloadHandlerAudioClip.GetContent(www);
-                    if (!string.IsNullOrEmpty(voice.Name))
+                    if (clip != null)
                     {
-                        // Cache if name is set
-                        audioCache[voice.Name] = clip;
+                        audioCache[voice.CacheKey] = clip;
                     }
                     return clip;
                 }


### PR DESCRIPTION
- To disable cache, set `false` to `Voice.UseCache`.
- Change the key for cache from `Voice.Name` to `Voice.CacheKey`. It is a read only property that returns Uri of Web voices or Text of TTS voices.

TODO: Clearing unnecessary cache