### PR TITLE
Reset viseme after speech #92

### DIFF
--- a/ChatdollKit/Editor/FaceClipEditor.cs
+++ b/ChatdollKit/Editor/FaceClipEditor.cs
@@ -259,6 +259,9 @@ public class FaceClipEditor : Editor
         // Set audio source
         modelController.AudioSource = lipSyncObject.GetComponent<AudioSource>();
 
+        // Set LipSyncContext
+        modelController.LipSyncContext = lipSyncObject.GetComponent<OVRLipSyncContext>();
+
         // Set blink target
         modelController.BlinkBlendShapeName = GetBlinkTargetName(modelController.SkinnedMeshRenderer);
     }


### PR DESCRIPTION
Also fix bug that `Say` aborts when canceled while waiting PreGap or Postgap.

NOTE: To enable this feature, run Setup ModelController from context menu on the inspector or set LipSyncContext manually to ModelController.