### PR TITLE
Enable to customize the first step of conversation

### DIFF
--- a/ChatdollKit/Scripts/Dialog/CameraRequestProvider.cs
+++ b/ChatdollKit/Scripts/Dialog/CameraRequestProvider.cs
@@ -23,9 +23,11 @@ namespace ChatdollKit.Dialog
         }
 
         // Create request using voice recognition
-        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token)
+        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token, Request preRequest = null)
         {
-            var request = new Request(RequestType, user);
+            var request = preRequest ?? new Request(RequestType);
+            request.User = user;
+
             var payloads = new List<Texture2D>();
 
             if (chatdollCamera != null)

--- a/ChatdollKit/Scripts/Dialog/IRequestProvider.cs
+++ b/ChatdollKit/Scripts/Dialog/IRequestProvider.cs
@@ -7,6 +7,6 @@ namespace ChatdollKit.Dialog
     public interface IRequestProvider
     {
         RequestType RequestType { get; }
-        Task<Request> GetRequestAsync(User user, Context context, CancellationToken token);
+        Task<Request> GetRequestAsync(User user, Context context, CancellationToken token, Request preRequest = null);
     }
 }

--- a/ChatdollKit/Scripts/Dialog/QRCodeRequestProvider.cs
+++ b/ChatdollKit/Scripts/Dialog/QRCodeRequestProvider.cs
@@ -20,9 +20,11 @@ namespace ChatdollKit.Dialog
         }
 
         // Create request using voice recognition
-        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token)
+        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token, Request preRequest = null)
         {
-            var request = new Request(RequestType, user);
+            var request = preRequest ?? new Request(RequestType);
+            request.User = user;
+
             var payloads = new List<string>();
 
             if (chatdollCamera != null)

--- a/ChatdollKit/Scripts/Dialog/Request.cs
+++ b/ChatdollKit/Scripts/Dialog/Request.cs
@@ -6,7 +6,7 @@ namespace ChatdollKit.Dialog
 {
     public enum RequestType
     {
-        Voice, Camera, QRCode
+        None, Voice, Camera, QRCode
     }
 
     public enum Priority

--- a/ChatdollKit/Scripts/Dialog/Request.cs
+++ b/ChatdollKit/Scripts/Dialog/Request.cs
@@ -19,7 +19,7 @@ namespace ChatdollKit.Dialog
         public string Id { get; }
         public RequestType Type { get; }
         public DateTime Timestamp { get; }
-        public User User { get; }
+        public User User { get; set; }
         public string Text { get; set; }
         public object Payloads { get; set; }
         public string Intent { get; set; }
@@ -29,12 +29,13 @@ namespace ChatdollKit.Dialog
         public bool IsAdhoc { get; set; }
         public bool IsCanceled { get; set; }
 
-        public Request(RequestType type, User user)
+        public Request(RequestType type)
         {
             Id = Guid.NewGuid().ToString();
             Type = type;
             Timestamp = DateTime.UtcNow;
-            User = user;
+            User = null;
+            Text = string.Empty;
             IntentPriority = Priority.Normal;
             Entities = new Dictionary<string, object>();
             IsAdhoc = false;

--- a/ChatdollKit/Scripts/Dialog/VoiceRequestProviderBase.cs
+++ b/ChatdollKit/Scripts/Dialog/VoiceRequestProviderBase.cs
@@ -79,8 +79,14 @@ namespace ChatdollKit.Dialog
 #pragma warning restore CS1998
 
         // Create request using voice recognition
-        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token)
+        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token, Request preRequest = null)
         {
+            if (preRequest != null && !string.IsNullOrEmpty(preRequest.Text))
+            {
+                preRequest.User = user;
+                return preRequest;
+            }
+
             voiceDetectionThreshold = VoiceDetectionThreshold;
             voiceDetectionMinimumLength = VoiceDetectionMinimumLength;
             silenceDurationToEndRecording = SilenceDurationToEndRecording;
@@ -93,10 +99,8 @@ namespace ChatdollKit.Dialog
 
             StartListening();
 
-            var request = new Request(RequestType, user)
-            {
-                Text = string.Empty
-            };
+            var request = preRequest ?? new Request(RequestType);
+            request.User = user;
 
             try
             {

--- a/Examples/HelloWorld/Scripts/RequestProvider.cs
+++ b/Examples/HelloWorld/Scripts/RequestProvider.cs
@@ -24,9 +24,10 @@ namespace ChatdollKit.Examples.HelloWorld
             = async (r, c, t) => { Debug.LogWarning("RequestProvider.OnErrorAsync is not implemented"); };
 
         // Create request using voice recognition
-        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token)
+        public async Task<Request> GetRequestAsync(User user, Context context, CancellationToken token, Request preRequest = null)
         {
-            var request = new Request(RequestType, user);
+            var request = preRequest ?? new Request(RequestType);
+            request.User = user;
 
             // Listen voice
             try


### PR DESCRIPTION
- Wakeword with request: Accept wakeword and request at the same time. You can say "Hey my sister, what's the weather today?"(wakeword+request) instead of "Hey my sister"(wakeword) -> "Hello, what's up?"(prompt) -> "What's the weather today?"(request).

- RequestType and intent for each wakeword: You can configure wakewords with RequestType and intent on inspector. For example, if you set `RequestType.QRCode` and `reception` intent for wakeword "reception", QRCode reader will be launched and conversation starts as reception mode.

NOTE: Handle these configuration in your app and use them to call `StartChatAsync` like below:

```csharp
Request preRequest = null;
if (wakeword.RequestType != RequestType.None || string.IsNullOrEmpty(wakeword.Intent))
{
    preRequest = new Request(wakeword.RequestType);
    preRequest.Intent = wakeword.Intent;
}
await chatdoll.StartChatAsync("user0123456789", preRequest: preRequest);
```

There are much more use cases regardless of using `WakeWordListener`. Start conversation periodically can be the one of them. Enjoy creating awesome chatdolls :)