### PR TITLE
Avoid using unnecessary Awake() and Start()

### DIFF
--- a/ChatdollKit/Scripts/Dialog/CameraRequestProvider.cs
+++ b/ChatdollKit/Scripts/Dialog/CameraRequestProvider.cs
@@ -17,9 +17,13 @@ namespace ChatdollKit.Dialog
 
         private ChatdollCamera chatdollCamera;
 
-        private void Start()
+        private void Awake()
         {
-            chatdollCamera = GameObject.Find("ChatdollCamera").GetComponent<ChatdollCamera>();
+            chatdollCamera = GameObject.Find("ChatdollCamera")?.GetComponent<ChatdollCamera>();
+            if (chatdollCamera == null)
+            {
+                Debug.LogError("ChatdollCamera not found. CameraRequestProvider doesn't work.");
+            }
         }
 
         // Create request using voice recognition

--- a/ChatdollKit/Scripts/Dialog/DialogRouterBase.cs
+++ b/ChatdollKit/Scripts/Dialog/DialogRouterBase.cs
@@ -11,12 +11,6 @@ namespace ChatdollKit.Dialog
     {
         protected Dictionary<string, IDialogProcessor> intentResolver = new Dictionary<string, IDialogProcessor>();
         protected Dictionary<string, IDialogProcessor> topicResolver = new Dictionary<string, IDialogProcessor>();
-        protected ModelController modelController;
-
-        protected virtual void Awake()
-        {
-            modelController = gameObject.GetComponent<ModelController>();
-        }
 
         public virtual void Configure()
         {

--- a/ChatdollKit/Scripts/Dialog/HttpDialogProcessor.cs
+++ b/ChatdollKit/Scripts/Dialog/HttpDialogProcessor.cs
@@ -8,13 +8,7 @@ namespace ChatdollKit.Dialog
     public class HttpDialogProcessor : DialogProcessorBase
     {
         public string DialogUri;
-        protected ChatdollHttp httpClient;
-
-        protected override void Awake()
-        {
-            base.Awake();
-            httpClient = new ChatdollHttp();
-        }
+        protected ChatdollHttp httpClient = new ChatdollHttp();
 
         private void OnDestroy()
         {

--- a/ChatdollKit/Scripts/Dialog/HttpPrompter.cs
+++ b/ChatdollKit/Scripts/Dialog/HttpPrompter.cs
@@ -14,12 +14,11 @@ namespace ChatdollKit.Dialog
         public string PingUri;
         protected Dictionary<string, AnimatedVoiceRequest> promptAnimatedVoices = new Dictionary<string, AnimatedVoiceRequest>();
         protected RequestType promptRequestType = RequestType.Voice;
-        protected ChatdollHttp httpClient;
+        protected ChatdollHttp httpClient = new ChatdollHttp();
         protected ModelController modelController;
 
         protected void Awake()
         {
-            httpClient = new ChatdollHttp();
             modelController = gameObject.GetComponent<ModelController>();
             if (modelController == null)
             {

--- a/ChatdollKit/Scripts/Dialog/QRCodeRequestProvider.cs
+++ b/ChatdollKit/Scripts/Dialog/QRCodeRequestProvider.cs
@@ -14,9 +14,13 @@ namespace ChatdollKit.Dialog
 
         private ChatdollCamera chatdollCamera;
 
-        private void Start()
+        private void Awake()
         {
-            chatdollCamera = GameObject.Find("ChatdollCamera").GetComponent<ChatdollCamera>();
+            chatdollCamera = GameObject.Find("ChatdollCamera")?.GetComponent<ChatdollCamera>();
+            if (chatdollCamera == null)
+            {
+                Debug.LogError("ChatdollCamera not found. CameraRequestProvider doesn't work.");
+            }
         }
 
         // Create request using voice recognition

--- a/ChatdollKit/Scripts/IO/ChatdollCamera.cs
+++ b/ChatdollKit/Scripts/IO/ChatdollCamera.cs
@@ -62,10 +62,7 @@ namespace ChatdollKit.IO
                 Permission.RequestUserPermission(Permission.Camera);
             }
 #endif
-        }
 
-        private void Start()
-        {
             backgroundPanel = gameObject.GetComponentInChildren<Image>(true)?.gameObject;
             if (backgroundPanel == null)
             {


### PR DESCRIPTION
To make the startup flow simply, avoid using `Awake()` and `Start()` if possible.

(Exception)
- In `Awake()`, `GetComponent(s)()` or initializing members that is independent from other components is allowed.
- In `Start()`, starting process that should be start automatically is allowed. (e.g. microphone)