### PR TITLE
Make it easier to use MessageWindow and ChatdollCamera

### DIFF
--- a/ChatdollKit/Scripts/ChatdollApplication.cs
+++ b/ChatdollKit/Scripts/ChatdollApplication.cs
@@ -30,8 +30,8 @@ namespace ChatdollKit
         public string PromptFace;
         public string PromptAnimation;
 
-        [Header("Message Window")]
-        public SimpleMessageWindow MessageWindow;
+        [Header("Voice Request Provider")]
+        public MessageWindowBase MessageWindow;
 
         [Header("Camera")]
         public ChatdollCamera ChatdollCamera;
@@ -145,9 +145,10 @@ namespace ChatdollKit
             // Voice Request Provider
             if (voiceRequestProvider != null)
             {
-                // Message window
+                // Set message window
                 if (voiceRequestProvider.MessageWindow == null)
                 {
+                    InstantiateMessageWindos();
                     voiceRequestProvider.MessageWindow = MessageWindow;
                 }
 
@@ -159,8 +160,45 @@ namespace ChatdollKit
             }
 
             // Camera and QRCode Request Provider
-            cameraRequestProvider.ChatdollCamera = ChatdollCamera;
-            qrcodeRequestProvider.ChatdollCamera = ChatdollCamera;
+            if (cameraRequestProvider.ChatdollCamera == null)
+            {
+                InstantiateCamera();
+                cameraRequestProvider.ChatdollCamera = ChatdollCamera;
+            }
+            if (qrcodeRequestProvider.ChatdollCamera == null)
+            {
+                InstantiateCamera();
+                qrcodeRequestProvider.ChatdollCamera = ChatdollCamera;
+            }
+        }
+
+        protected virtual void InstantiateMessageWindos()
+        {
+            if (MessageWindow == null)
+            {
+                // Create instance of SimpleMessageWindow
+                var messageWindowGameObject = Resources.Load<GameObject>("Prefabs/SimpleMessageWindow/SimpleMessageWindow");
+                if (messageWindowGameObject != null)
+                {
+                    var messageWindowGameObjectInstance = Instantiate(messageWindowGameObject);
+                    messageWindowGameObjectInstance.name = messageWindowGameObject.name;
+                    MessageWindow = messageWindowGameObjectInstance.GetComponent<SimpleMessageWindow>();
+                }
+            }
+        }
+
+        protected virtual void InstantiateCamera()
+        {
+            if (ChatdollCamera == null)
+            {
+                var cameraGameObject = Resources.Load<GameObject>("Prefabs/ChatdollCamera");
+                if (cameraGameObject != null)
+                {
+                    var cameraGameObjectInstance = Instantiate(cameraGameObject);
+                    cameraGameObjectInstance.name = cameraGameObject.name;
+                    ChatdollCamera = cameraGameObjectInstance.GetComponent<ChatdollCamera>();
+                }
+            }
         }
 
         protected virtual string GetUserId()

--- a/ChatdollKit/Scripts/Dialog/IMessageWindow.cs
+++ b/ChatdollKit/Scripts/Dialog/IMessageWindow.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace ChatdollKit.Dialog
+{
+    public interface IMessageWindow
+    {
+        void Show(string prompt = null);
+        void Hide();
+        Task ShowMessageAsync(string message, CancellationToken token);
+        Task SetMessageAsync(string message, CancellationToken token);
+    }
+}

--- a/ChatdollKit/Scripts/Dialog/MessageWindowBase.cs
+++ b/ChatdollKit/Scripts/Dialog/MessageWindowBase.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace ChatdollKit.Dialog
+{
+    // Unity2018 support (inspector does not support interface)
+    public class MessageWindowBase : MonoBehaviour, IMessageWindow
+    {
+        public virtual void Show(string prompt = null)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public virtual void Hide()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public virtual Task ShowMessageAsync(string message, CancellationToken token)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public virtual Task SetMessageAsync(string message, CancellationToken token)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/ChatdollKit/Scripts/Dialog/SimpleMessageWindow.cs
+++ b/ChatdollKit/Scripts/Dialog/SimpleMessageWindow.cs
@@ -4,10 +4,9 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 
-
 namespace ChatdollKit.Dialog
 {
-    public class SimpleMessageWindow : MonoBehaviour
+    public class SimpleMessageWindow : MessageWindowBase
     {
         private Text MessageText;
         public float MessageSpeed = 0.05f;
@@ -15,27 +14,28 @@ namespace ChatdollKit.Dialog
         public float PostGap = 1.0f;
         private string CurrentMessageId;
 
-        public void Show(string prompt = null)
+        public override void Show(string prompt = null)
         {
             SetActive(true);
             if (prompt != null)
             {
-                ShowPrompt(prompt);
+                MessageText.text = prompt;
             }
         }
 
-        public void Hide()
+        public override void Hide()
         {
             SetActive(false);
             MessageText.text = string.Empty;
         }
 
-        public void ShowPrompt(string prompt)
+        public override async Task ShowMessageAsync(string message, CancellationToken token)
         {
-            MessageText.text = prompt;
+            Show();
+            await SetMessageAsync(message, token);
         }
 
-        public async Task SetMessageAsync(string message, CancellationToken token)
+        public override async Task SetMessageAsync(string message, CancellationToken token)
         {
             var messageId = Guid.NewGuid().ToString();
             CurrentMessageId = messageId;

--- a/ChatdollKit/Scripts/Dialog/VoiceRequestProviderBase.cs
+++ b/ChatdollKit/Scripts/Dialog/VoiceRequestProviderBase.cs
@@ -30,7 +30,7 @@ namespace ChatdollKit.Dialog
         public float ListeningTimeout = 20.0f;
 
         [Header("UI")]
-        public SimpleMessageWindow MessageWindow;
+        public MessageWindowBase MessageWindow;
 
         public Action OnListeningStart;
         public Action OnListeningStop;


### PR DESCRIPTION
- You can use `SimpleMessageWindow` and `ChatdollCamera` without configuration as long as using `ChatdollApplication` and its subclass.
- You can create your own message window and configure it to `VoiceRequestProvider` on inspector.