### PR TITLE
Make CancelWord set from application config to VoiceRequestProvider

### DIFF
--- a/ChatdollKit/Scripts/ChatdollApplication.cs
+++ b/ChatdollKit/Scripts/ChatdollApplication.cs
@@ -112,6 +112,15 @@ namespace ChatdollKit
                 Debug.LogWarning("Request providers are missing");
             }
 
+            // Register cancel word to VoiceRequestProvider
+            if (voiceRequestProvider?.CancelWords.Count == 0)
+            {
+                if (!string.IsNullOrEmpty(CancelWord))
+                {
+                    voiceRequestProvider.CancelWords.Add(CancelWord);
+                }
+            }
+
             // Create DialogController with components
             dialogController = new DialogController(userStore, stateStore, skillRouter, enabledRequestProviders, modelController);
 


### PR DESCRIPTION
If you configure CancelWord(s) directly to VoiceRequestProvider on inspector, they will be preferred.
This feature is just a short cut way of configuration.