### PR TITLE
Add simple chat example that doesn't require API key

### DIFF
--- a/Examples/Chat/MainAzure.cs
+++ b/Examples/Chat/MainAzure.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+using ChatdollKit.Extension.Azure;
+
+namespace ChatdollKit.Examples.Chat
+{
+    [RequireComponent(typeof(DemoChatSkill))]
+    public class MainAzure : AzureApplication
+    {
+
+    }
+}

--- a/Examples/Chat/MainGoogle.cs
+++ b/Examples/Chat/MainGoogle.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+using ChatdollKit.Extension.Google;
+
+namespace ChatdollKit.Examples.Chat
+{
+    [RequireComponent(typeof(DemoChatSkill))]
+    public class MainGoogle : GoogleApplication
+    {
+
+    }
+}

--- a/Examples/Chat/MainWatson.cs
+++ b/Examples/Chat/MainWatson.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+using ChatdollKit.Extension.Watson;
+
+namespace ChatdollKit.Examples.Chat
+{
+    [RequireComponent(typeof(DemoChatSkill))]
+    public class MainWatson : WatsonApplication
+    {
+
+    }
+}

--- a/Examples/Chat/Skills/DemoChatSkill.cs
+++ b/Examples/Chat/Skills/DemoChatSkill.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+using ChatdollKit.Dialog;
+using ChatdollKit.Network;
+
+namespace ChatdollKit.Examples.Chat
+{
+    public class DemoChatSkill : SkillBase
+    {
+        private ChatdollHttp client = new ChatdollHttp();
+
+        private void OnDestroy()
+        {
+            client.Dispose();
+        }
+
+        public override async Task<Response> ProcessAsync(Request request, State state, CancellationToken token)
+        {
+            // Build and return response message
+            var response = new Response(request.Id);
+
+            // Get chat response message from server
+            var encodedText = UnityWebRequest.EscapeURL(request.Text);
+            var chatResponse = await client.GetJsonAsync<DemoChatResponse>($"https://api.uezo.net/chat/?input={encodedText}");
+            if (chatResponse != null && chatResponse.outputs.Count > 0)
+            {
+                Random.InitState(System.DateTime.Now.Millisecond);
+                response.AddVoiceTTS(chatResponse.outputs[0].val[Random.Range(0, chatResponse.outputs[0].val.Count)]);
+                state.Topic.IsFinished = false; // Continue chatting
+            }
+            else
+            {
+                Debug.LogWarning("No response");
+                Debug.LogWarning(chatResponse.outputs.Count);
+            }
+
+            return response;
+        }
+
+        class DemoChatResponse
+        {
+            public List<ResponseOutput> outputs;
+        }
+
+        class ResponseOutput
+        {
+            public List<float> score;
+            public List<string> val;
+        }
+    }
+}


### PR DESCRIPTION
The ChatdollKit project provides the chat API for demo. This is not for production use. Just for running examples and demo.