### PR TITLE
Add support for microphone on WebGL🎤

### DIFF
--- a/ChatdollKit/Plugins.meta
+++ b/ChatdollKit/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7aade3f749b20461a8af29a6b4cc9bfa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChatdollKit/Plugins/WebGLMicrophone.jslib
+++ b/ChatdollKit/Plugins/WebGLMicrophone.jslib
@@ -1,0 +1,56 @@
+mergeInto(LibraryManager.library, {
+    InitWebGLMicrophone: function(targetObjectNamePtr) {
+        // Initialize webGLMicrophone
+        document.webGLMicrophone = new Object();
+        document.webGLMicrophone.isRecording = 0;
+        document.webGLMicrophone.targetObjectName = UTF8ToString(targetObjectNamePtr);
+        document.webGLMicrophone.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+
+        // Observe the state of audio context for microphone and resume if disabled
+        setInterval(function() {
+            if (document.webGLMicrophone.audioContext.state === "suspended" || document.webGLMicrophone.audioContext.state === "interrupted") {
+                console.log("Resuming AudioContext: " + document.webGLMicrophone.audioContext.state);
+                document.webGLMicrophone.audioContext.resume();
+            }
+        }, 300);
+    },
+
+    StartWebGLMicrophone: function() {
+        if (navigator.mediaDevices.getUserMedia) {
+            navigator.mediaDevices.getUserMedia({ audio: true })
+            .then(function(stream) {
+                // Setup nodes
+                var audioContext = document.webGLMicrophone.audioContext;
+                var source = audioContext.createMediaStreamSource(stream);
+                var scriptNode = audioContext.createScriptProcessor(4096, 1, 1);
+                scriptNode.onaudioprocess = function (stream) {
+                    SendMessage(document.webGLMicrophone.targetObjectName, "SetSamplingData", event.inputBuffer.getChannelData(0).join(','));
+                };
+                // Connect nodes;
+                source.connect(scriptNode);
+                scriptNode.connect(audioContext.destination);
+
+                document.webGLMicrophone.scriptNode = scriptNode;
+                document.webGLMicrophone.source = source;
+                document.webGLMicrophone.isRecording = 1;
+
+                console.log('record started by uezo new logic');
+            })
+            .catch(function(err) {
+                console.log("Failed in GetUserMedia: " + error);
+            });
+        }
+    },
+
+    EndWebGLMicrophone: function() {
+        document.webGLMicrophone.source.disconnect(document.webGLMicrophone.scriptNode);
+        document.webGLMicrophone.source = null;
+        document.webGLMicrophone.scriptNode.disconnect();
+        document.webGLMicrophone.scriptNode = null;
+        document.webGLMicrophone.isRecording = 0;
+    },
+
+    IsWebGLMicrophoneRecording: function() {
+        return document.webGLMicrophone.isRecording == 1;
+    },
+});

--- a/ChatdollKit/Plugins/WebGLMicrophone.jslib.meta
+++ b/ChatdollKit/Plugins/WebGLMicrophone.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: c28bdda4028615f41be3db5d12e1333a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChatdollKit/Scripts/Dialog/VoiceRequestProviderBase.cs
+++ b/ChatdollKit/Scripts/Dialog/VoiceRequestProviderBase.cs
@@ -135,7 +135,7 @@ namespace ChatdollKit.Dialog
                     }
                     else if (voiceRecorderResponse != null && voiceRecorderResponse.Voice != null)
                     {
-                        request.Text = await RecognizeSpeechAsync(voiceRecorderResponse.Voice);
+                        request.Text = await RecognizeSpeechAsync(voiceRecorderResponse);
                         if (OnRecognizedAsync != null)
                         {
                             await OnRecognizedAsync(request.Text);
@@ -186,7 +186,7 @@ namespace ChatdollKit.Dialog
         }
 
 #pragma warning disable CS1998
-        protected virtual async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected virtual async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             throw new NotImplementedException("RecognizeSpeechAsync method should be implemented at the sub class of VoiceRequestProviderBase");
         }

--- a/ChatdollKit/Scripts/Dialog/WakeWordListenerBase.cs
+++ b/ChatdollKit/Scripts/Dialog/WakeWordListenerBase.cs
@@ -38,10 +38,10 @@ namespace ChatdollKit.Dialog
             }
         }
 
-        protected override async UniTask ProcessVoiceAsync(AudioClip voice)
+        protected override async UniTask ProcessVoiceAsync(VoiceRecorderResponse voiceRecorderResponse)
         {
             // Recognize speech
-            var recognizedText = await RecognizeSpeechAsync(voice);
+            var recognizedText = await RecognizeSpeechAsync(voiceRecorderResponse);
             if (OnRecognizedAsync != null)
             {
                 await OnRecognizedAsync(recognizedText);
@@ -125,7 +125,7 @@ namespace ChatdollKit.Dialog
         }
 
 #pragma warning disable CS1998
-        protected virtual async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected virtual async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             throw new NotImplementedException("RecognizeSpeechAsync method should be implemented at the sub class of WakeWordListenerBase");
         }

--- a/ChatdollKit/Scripts/IO/AudioConverter.cs
+++ b/ChatdollKit/Scripts/IO/AudioConverter.cs
@@ -2,17 +2,16 @@
 using System.Text;
 using UnityEngine;
 
-
 namespace ChatdollKit.IO
 {
     public static class AudioConverter
     {
-        public static string AudioClipToBase64(AudioClip audioClip)
+        public static string AudioClipToBase64(AudioClip audioClip, float[] samplingData = null)
         {
-            return Convert.ToBase64String(AudioClipToPCM(audioClip));
+            return Convert.ToBase64String(AudioClipToPCM(audioClip, samplingData));
         }
 
-        public static byte[] AudioClipToPCM(AudioClip audioClip)
+        public static byte[] AudioClipToPCM(AudioClip audioClip, float[] samplingData = null)
         {
             var pcm = new byte[audioClip.samples * audioClip.channels * 2 + 44];
 
@@ -31,9 +30,13 @@ namespace ChatdollKit.IO
             Array.Copy(Encoding.ASCII.GetBytes("data"), 0, pcm, 36, 4);
             Array.Copy(BitConverter.GetBytes((UInt32)audioClip.samples * 2), 0, pcm, 40, 4);
 
-            // Add PCM Data
-            var samplingData = new float[audioClip.samples * audioClip.channels];
-            audioClip.GetData(samplingData, 0);
+            if (samplingData == null)
+            {
+                // Try to get sampling data from audio clip. This will not work on WebGL platform
+                samplingData = new float[audioClip.samples * audioClip.channels];
+                audioClip.GetData(samplingData, 0);
+            }
+
             for (var i = 0; i < samplingData.Length; i++)
             {
                 // float to 16bit int to bytes

--- a/ChatdollKit/Scripts/IO/ChatdollMicrophone.cs
+++ b/ChatdollKit/Scripts/IO/ChatdollMicrophone.cs
@@ -4,7 +4,11 @@ using UnityEngine;
 #if PLATFORM_ANDROID
 using UnityEngine.Android;
 #endif
-
+# if UNITY_WEBGL && !UNITY_EDITOR
+using Microphone = ChatdollKit.IO.WebGLMicrophone;
+# else
+using Microphone = UnityEngine.Microphone;
+#endif
 
 namespace ChatdollKit.IO
 {
@@ -37,6 +41,13 @@ namespace ChatdollKit.IO
             if (!Permission.HasUserAuthorizedPermission(Permission.Microphone))
             {
                 Permission.RequestUserPermission(Permission.Microphone);
+            }
+#endif
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            if (gameObject.GetComponent<ChatdollKit.IO.WebGLMicrophone>() == null)
+            {
+                gameObject.AddComponent<ChatdollKit.IO.WebGLMicrophone>();
             }
 #endif
         }

--- a/ChatdollKit/Scripts/IO/ShortPhraseListner.cs
+++ b/ChatdollKit/Scripts/IO/ShortPhraseListner.cs
@@ -86,7 +86,7 @@ namespace ChatdollKit.IO
                         if (voiceRecorderResponse.Voice.length <= VoiceRecognitionMaximumLength)
                         {
 #pragma warning disable CS4014
-                            ProcessVoiceAsync(voiceRecorderResponse.Voice); // Do not await to continue listening
+                            ProcessVoiceAsync(voiceRecorderResponse); // Do not await to continue listening
 #pragma warning restore CS4014
                         }
                     }
@@ -103,7 +103,7 @@ namespace ChatdollKit.IO
         }
 
 #pragma warning disable CS1998
-        protected virtual async UniTask ProcessVoiceAsync(AudioClip voice)
+        protected virtual async UniTask ProcessVoiceAsync(VoiceRecorderResponse voiceRecorderResponse)
         {
 
         }

--- a/ChatdollKit/Scripts/IO/VoiceRecorderBase.cs
+++ b/ChatdollKit/Scripts/IO/VoiceRecorderBase.cs
@@ -22,6 +22,7 @@ namespace ChatdollKit.IO
 
         // Runtime configurations
         protected float voiceDetectionThreshold;
+        protected float voiceDetectionMaxThreshold = 0.7f;
         protected float voiceDetectionMinimumLength;
         protected float silenceDurationToEndRecording;
         protected Action onListeningStart;
@@ -51,7 +52,7 @@ namespace ChatdollKit.IO
 
                 // Handle recorded voice
                 recordedData.AddRange(capturedData.Data);
-                if (capturedData.MaxVolume > voiceDetectionThreshold)
+                if (capturedData.MaxVolume > voiceDetectionThreshold && capturedData.MaxVolume < voiceDetectionMaxThreshold)
                 {
                     onDetectVoice?.Invoke(capturedData.MaxVolume);
 

--- a/ChatdollKit/Scripts/IO/VoiceRecorderBase.cs
+++ b/ChatdollKit/Scripts/IO/VoiceRecorderBase.cs
@@ -78,14 +78,8 @@ namespace ChatdollKit.IO
                             var recordedLength = recordedData.Count / (float)(capturedData.Frequency * capturedData.ChannelCount) - silenceDurationToEndRecording;
                             if (recordedLength >= voiceDetectionMinimumLength)
                             {
-                                // Create AudioClip and copy recorded data
-                                var audioClip = AudioClip.Create(string.Empty, recordedData.Count, capturedData.ChannelCount, capturedData.Frequency, false);
-                                audioClip.SetData(recordedData.ToArray(), 0);
-
-                                // Give reference of audio clip to all audiences
-                                lastRecordedVoice = new VoiceRecorderResponse() { RecordingStartedAt = recordingStartTime, Voice = audioClip };
-
-                                onRecordingEnd?.Invoke(audioClip);
+                                lastRecordedVoice = new VoiceRecorderResponse(recordingStartTime, recordedData, capturedData.ChannelCount, capturedData.Frequency);
+                                onRecordingEnd?.Invoke(lastRecordedVoice.Voice);
                             }
                             else
                             {
@@ -178,5 +172,14 @@ namespace ChatdollKit.IO
     {
         public float RecordingStartedAt { get; set; }
         public AudioClip Voice { get; set; }
+        public float[] SamplingData { get; set; }
+
+        public VoiceRecorderResponse(float recordingStartedAt, List<float> samplingDataList, int channelCount, int frequency)
+        {
+            RecordingStartedAt = recordingStartedAt;
+            SamplingData = samplingDataList.ToArray();
+            Voice = AudioClip.Create(string.Empty, samplingDataList.Count, channelCount, frequency, false);
+            Voice.SetData(SamplingData, 0);
+        }
     }
 }

--- a/ChatdollKit/Scripts/IO/WebGLMicrophone.cs
+++ b/ChatdollKit/Scripts/IO/WebGLMicrophone.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace ChatdollKit.IO
+{
+    public class WebGLMicrophone : MonoBehaviour
+    {
+        [DllImport("__Internal")]
+        private static extern void InitWebGLMicrophone(string targetObjectName);
+        [DllImport("__Internal")]
+        private static extern void StartWebGLMicrophone();
+        [DllImport("__Internal")]
+        private static extern void EndWebGLMicrophone();
+        [DllImport("__Internal")]
+        private static extern int IsWebGLMicrophoneRecording();
+
+        public static readonly string[] devices = new string[0];
+        private static int FIXED_FREQUENCY = 44100;
+
+        private AudioClip microphoneClip;
+        private float[] capturedData;
+        private bool loop;
+        private int currentPosition;
+
+        // Singleton
+        private static WebGLMicrophone instance;
+        public static WebGLMicrophone Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = FindObjectOfType<WebGLMicrophone>();
+                    if (instance == null)
+                    {
+                        Debug.LogError("WebGLMicrophone not found. Attach WebGLMicrophone to the GameObject you like.");
+                    }
+                }
+                return instance;
+            }
+        }
+
+        private void Awake()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            InitWebGLMicrophone(gameObject.name);
+#endif
+        }
+
+        public static AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency)
+        {
+            if (!IsRecording(deviceName))
+            {
+                Instance.loop = loop;
+                Instance.currentPosition = 0;
+                var channels = 1;   // デバイスから取得できるのであればするけど・・・
+                Instance.capturedData = new float[FIXED_FREQUENCY * lengthSec * channels];
+                if (Instance.microphoneClip != null)
+                {
+                    Destroy(Instance.microphoneClip);
+                }
+                Instance.microphoneClip = AudioClip.Create("WebGL Microphone", FIXED_FREQUENCY * lengthSec, channels, FIXED_FREQUENCY, false);
+
+                StartWebGLMicrophone();
+            }
+
+            return Instance.microphoneClip;
+        }
+
+
+        public static void End(string deviceName)
+        {
+            if (IsRecording(deviceName))
+            {
+                EndWebGLMicrophone();
+            }
+        }
+
+        public static bool IsRecording(string deviceName)
+        {
+            return IsWebGLMicrophoneRecording() == 1;
+        }
+
+        public static void GetDeviceCaps(string deviceName, out int minFreq, out int maxfreq)
+        {
+            minFreq = FIXED_FREQUENCY;
+            maxfreq = FIXED_FREQUENCY;
+        }
+
+        public static int GetPosition(string deviceName)
+        {
+            return Instance.currentPosition;
+        }
+
+        private void SetSamplingData(string samplingDataString)
+        {
+            var samplingData = samplingDataString.Split(',').Select(s => Convert.ToSingle(s)).ToArray();
+
+
+            for (int i = 0; i < samplingData.Length; i++)
+            {
+                capturedData[currentPosition] = samplingData[i];
+                currentPosition++;
+                if (currentPosition == capturedData.Length)
+                {
+                    if (loop)
+                    {
+                        currentPosition = 0;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (microphoneClip != null)
+            {
+                microphoneClip.SetData(capturedData, 0);
+            }
+        }
+    }
+}

--- a/ChatdollKit/Scripts/IO/WebGLMicrophone.cs.meta
+++ b/ChatdollKit/Scripts/IO/WebGLMicrophone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc9f53a61bcd64c3b8058a44cad09928
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Extension/Azure/AzureVoiceRequestProvider.cs
+++ b/Extension/Azure/AzureVoiceRequestProvider.cs
@@ -36,13 +36,12 @@ namespace ChatdollKit.Extension.Azure
             // https://docs.microsoft.com/ja-jp/azure/cognitive-services/speech-service/rest-speech-to-text#chunked-transfer
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"https://{Region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={Language}",
-                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice, recordedVoice.SamplingData),
                 headers);
 
             return response?.DisplayText ?? string.Empty;
         }
 
-#pragma warning disable CS0649
         // Response from Azure STT
         class SpeechRecognitionResponse
         {

--- a/Extension/Azure/AzureVoiceRequestProvider.cs
+++ b/Extension/Azure/AzureVoiceRequestProvider.cs
@@ -20,7 +20,7 @@ namespace ChatdollKit.Extension.Azure
             Region = string.IsNullOrEmpty(Region) || overwrite ? region : Region;
         }
 
-        protected override async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             if (string.IsNullOrEmpty(ApiKey) || string.IsNullOrEmpty(Region) || string.IsNullOrEmpty(Language))
             {
@@ -36,7 +36,7 @@ namespace ChatdollKit.Extension.Azure
             // https://docs.microsoft.com/ja-jp/azure/cognitive-services/speech-service/rest-speech-to-text#chunked-transfer
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"https://{Region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={Language}",
-                AudioConverter.AudioClipToPCM(recordedVoice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
                 headers);
 
             return response?.DisplayText ?? string.Empty;

--- a/Extension/Azure/AzureWakeWordListener.cs
+++ b/Extension/Azure/AzureWakeWordListener.cs
@@ -36,13 +36,12 @@ namespace ChatdollKit.Extension.Azure
             // https://docs.microsoft.com/ja-jp/azure/cognitive-services/speech-service/rest-speech-to-text#chunked-transfer
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"https://{Region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={Language}",
-                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice, recordedVoice.SamplingData),
                 headers);
 
             return response?.DisplayText ?? string.Empty;
         }
 
-#pragma warning disable CS0649
         // Response from Azure STT
         class SpeechRecognitionResponse
         {

--- a/Extension/Azure/AzureWakeWordListener.cs
+++ b/Extension/Azure/AzureWakeWordListener.cs
@@ -20,7 +20,7 @@ namespace ChatdollKit.Extension.Azure
             Region = string.IsNullOrEmpty(Region) || overwrite ? region : Region;
         }
 
-        protected override async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             if (string.IsNullOrEmpty(ApiKey) || string.IsNullOrEmpty(Region) || string.IsNullOrEmpty(Language))
             {
@@ -36,7 +36,7 @@ namespace ChatdollKit.Extension.Azure
             // https://docs.microsoft.com/ja-jp/azure/cognitive-services/speech-service/rest-speech-to-text#chunked-transfer
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"https://{Region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={Language}",
-                AudioConverter.AudioClipToPCM(recordedVoice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
                 headers);
 
             return response?.DisplayText ?? string.Empty;

--- a/Extension/Google/GoogleVoiceRequestProvider.cs
+++ b/Extension/Google/GoogleVoiceRequestProvider.cs
@@ -27,22 +27,21 @@ namespace ChatdollKit.Extension.Google
 
             var response = await client.PostJsonAsync<SpeechRecognitionResponse>(
                 $"https://speech.googleapis.com/v1/speech:recognize?key={ApiKey}",
-                new SpeechRecognitionRequest(recordedVoice.Voice, Language, UseEnhancedModel));
+                new SpeechRecognitionRequest(recordedVoice.Voice, Language, UseEnhancedModel, recordedVoice.SamplingData));
 
             return response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;
         }
 
-#pragma warning disable CS0649
         // Models for request and response
         class SpeechRecognitionRequest
         {
             public SpeechRecognitionConfig config;
             public SpeechRecognitionAudio audio;
 
-            public SpeechRecognitionRequest(AudioClip audioClip, string languageCode, bool useEnhancedModel)
+            public SpeechRecognitionRequest(AudioClip audioClip, string languageCode, bool useEnhancedModel, float[] samplingData = null)
             {
                 config = new SpeechRecognitionConfig(audioClip, languageCode, useEnhancedModel);
-                audio = new SpeechRecognitionAudio(AudioConverter.AudioClipToBase64(audioClip));
+                audio = new SpeechRecognitionAudio(AudioConverter.AudioClipToBase64(audioClip, samplingData));
             }
         }
 

--- a/Extension/Google/GoogleVoiceRequestProvider.cs
+++ b/Extension/Google/GoogleVoiceRequestProvider.cs
@@ -18,7 +18,7 @@ namespace ChatdollKit.Extension.Google
             Language = string.IsNullOrEmpty(Language) || overwrite ? language : Language;
         }
 
-        protected override async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             if (string.IsNullOrEmpty(ApiKey) || string.IsNullOrEmpty(Language))
             {
@@ -27,7 +27,7 @@ namespace ChatdollKit.Extension.Google
 
             var response = await client.PostJsonAsync<SpeechRecognitionResponse>(
                 $"https://speech.googleapis.com/v1/speech:recognize?key={ApiKey}",
-                new SpeechRecognitionRequest(recordedVoice, Language, UseEnhancedModel));
+                new SpeechRecognitionRequest(recordedVoice.Voice, Language, UseEnhancedModel));
 
             return response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;
         }

--- a/Extension/Google/GoogleWakeWordListener.cs
+++ b/Extension/Google/GoogleWakeWordListener.cs
@@ -27,22 +27,21 @@ namespace ChatdollKit.Extension.Google
 
             var response = await client.PostJsonAsync<SpeechRecognitionResponse>(
                 $"https://speech.googleapis.com/v1/speech:recognize?key={ApiKey}",
-                new SpeechRecognitionRequest(recordedVoice.Voice, Language, UseEnhancedModel));
+                new SpeechRecognitionRequest(recordedVoice.Voice, Language, UseEnhancedModel, recordedVoice.SamplingData));
 
             return response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;
         }
 
-#pragma warning disable CS0649
         // Models for request and response
         class SpeechRecognitionRequest
         {
             public SpeechRecognitionConfig config;
             public SpeechRecognitionAudio audio;
 
-            public SpeechRecognitionRequest(AudioClip audioClip, string languageCode, bool useEnhancedModel)
+            public SpeechRecognitionRequest(AudioClip audioClip, string languageCode, bool useEnhancedModel, float[] samplingData = null)
             {
                 config = new SpeechRecognitionConfig(audioClip, languageCode, useEnhancedModel);
-                audio = new SpeechRecognitionAudio(AudioConverter.AudioClipToBase64(audioClip));
+                audio = new SpeechRecognitionAudio(AudioConverter.AudioClipToBase64(audioClip, samplingData));
             }
         }
 

--- a/Extension/Google/GoogleWakeWordListener.cs
+++ b/Extension/Google/GoogleWakeWordListener.cs
@@ -18,7 +18,7 @@ namespace ChatdollKit.Extension.Google
             Language = string.IsNullOrEmpty(Language) || overwrite ? language : Language;
         }
 
-        protected override async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             if (string.IsNullOrEmpty(ApiKey) || string.IsNullOrEmpty(Language))
             {
@@ -27,7 +27,7 @@ namespace ChatdollKit.Extension.Google
 
             var response = await client.PostJsonAsync<SpeechRecognitionResponse>(
                 $"https://speech.googleapis.com/v1/speech:recognize?key={ApiKey}",
-                new SpeechRecognitionRequest(recordedVoice, Language, UseEnhancedModel));
+                new SpeechRecognitionRequest(recordedVoice.Voice, Language, UseEnhancedModel));
 
             return response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;
         }

--- a/Extension/Watson/WatsonVoiceRequestProvider.cs
+++ b/Extension/Watson/WatsonVoiceRequestProvider.cs
@@ -38,7 +38,7 @@ namespace ChatdollKit.Extension.Watson
             // TODO: Accept more parameters
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"{BaseUrl}/v1/recognize?model={Model}",
-                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice, recordedVoice.SamplingData),
                 headers);
 
             var recognizedText = response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;
@@ -49,7 +49,6 @@ namespace ChatdollKit.Extension.Watson
             return recognizedText;
         }
 
-#pragma warning disable CS0649
         // Models for response
         public class SpeechRecognitionResponse
         {

--- a/Extension/Watson/WatsonVoiceRequestProvider.cs
+++ b/Extension/Watson/WatsonVoiceRequestProvider.cs
@@ -22,7 +22,7 @@ namespace ChatdollKit.Extension.Watson
             RemoveWordSeparation = overwrite ? removeWordSeparation : RemoveWordSeparation;
         }
 
-        protected override async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             if (string.IsNullOrEmpty(ApiKey) || string.IsNullOrEmpty(Model) || string.IsNullOrEmpty(BaseUrl))
             {
@@ -38,7 +38,7 @@ namespace ChatdollKit.Extension.Watson
             // TODO: Accept more parameters
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"{BaseUrl}/v1/recognize?model={Model}",
-                AudioConverter.AudioClipToPCM(recordedVoice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
                 headers);
 
             var recognizedText = response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;

--- a/Extension/Watson/WatsonWakeWordListener.cs
+++ b/Extension/Watson/WatsonWakeWordListener.cs
@@ -38,7 +38,7 @@ namespace ChatdollKit.Extension.Watson
             // TODO: Accept more parameters
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"{BaseUrl}/v1/recognize?model={Model}",
-                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice, recordedVoice.SamplingData),
                 headers);
 
             var recognizedText = response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;
@@ -49,7 +49,6 @@ namespace ChatdollKit.Extension.Watson
             return recognizedText;
         }
 
-#pragma warning disable CS0649
         // Models for response
         public class SpeechRecognitionResponse
         {

--- a/Extension/Watson/WatsonWakeWordListener.cs
+++ b/Extension/Watson/WatsonWakeWordListener.cs
@@ -22,7 +22,7 @@ namespace ChatdollKit.Extension.Watson
             RemoveWordSeparation = overwrite ? removeWordSeparation : RemoveWordSeparation;
         }
 
-        protected override async UniTask<string> RecognizeSpeechAsync(AudioClip recordedVoice)
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
         {
             if (string.IsNullOrEmpty(ApiKey) || string.IsNullOrEmpty(Model) || string.IsNullOrEmpty(BaseUrl))
             {
@@ -38,7 +38,7 @@ namespace ChatdollKit.Extension.Watson
             // TODO: Accept more parameters
             var response = await client.PostBytesAsync<SpeechRecognitionResponse>(
                 $"{BaseUrl}/v1/recognize?model={Model}",
-                AudioConverter.AudioClipToPCM(recordedVoice),
+                AudioConverter.AudioClipToPCM(recordedVoice.Voice),
                 headers);
 
             var recognizedText = response?.results?[0]?.alternatives?[0]?.transcript ?? string.Empty;


### PR DESCRIPTION
You can use `ChatdollMicrophone` on WebGL platform that the Unity standard `Microphone` doesn't support. `ChatdollMicrophone` automatically switches between standard `Microphone` and `WebGLMicrophone` (internally uses MediaDevices.getUserMedia() on browser JS) without any configurations.

Of course the components based on `ChatdollMicrophone` like WakeWordListeners and VoiceRequestProviders also work on WebGL👍