### PR TITLE
Fix bug that voice cache doesn't work

### DIFF
--- a/Scripts/Model/WebVoiceLoaderBase.cs
+++ b/Scripts/Model/WebVoiceLoaderBase.cs
@@ -109,6 +109,11 @@ namespace ChatdollKit.Model
             return audioCache.ContainsKey(voice.CacheKey);
         }
 
+        public void ClearCache()
+        {
+            audioCache.Clear();
+        }
+
         public bool IsLoading(Voice voice)
         {
             if (audioDownloadTasks.ContainsKey(voice.CacheKey))

--- a/Scripts/Model/WebVoiceLoaderBase.cs
+++ b/Scripts/Model/WebVoiceLoaderBase.cs
@@ -18,6 +18,9 @@ namespace ChatdollKit.Model
         protected Dictionary<string, AudioClip> audioCache { get; set; } = new Dictionary<string, AudioClip>();
         protected Dictionary<string, UniTask<AudioClip>> audioDownloadTasks { get; set; } = new Dictionary<string, UniTask<AudioClip>>();
 
+        [SerializeField]
+        protected bool isDebug;
+
         protected virtual void Start()
         {
             // Instantiate at Start() to allow user to update Timeout at Awake()
@@ -28,9 +31,11 @@ namespace ChatdollKit.Model
         {
             if (IsLoading(voice))
             {
-                // Wait complete download task if download is now in progress.
-                // Cache is controlled by another task that originally invoked the download task
-                await WaitDownloadCancellable(audioDownloadTasks[voice.CacheKey], cancellationToken);
+                // Wait for cache is ready or task is canceled
+                while (!audioCache.ContainsKey(voice.CacheKey) || cancellationToken.IsCancellationRequested)
+                {
+                    await UniTask.Delay(50, cancellationToken: cancellationToken);
+                }
             }
 
             if (HasCache(voice))
@@ -41,10 +46,18 @@ namespace ChatdollKit.Model
                 {
                     audioCache.Remove(voice.CacheKey);
                 }
+                if (isDebug)
+                {
+                    Debug.Log($"Return cached audio clip: {voice.CacheKey}");
+                }
                 return cachedClip;
             }
 
             // Start download when download in not in progress and cache doesn't exist
+            if (isDebug)
+            {
+                Debug.Log($"Start downloading: {voice.CacheKey}");
+            }
             audioDownloadTasks[voice.CacheKey] = DownloadAudioClipAsync(voice, cancellationToken).Preserve();
             await WaitDownloadCancellable(audioDownloadTasks[voice.CacheKey], cancellationToken);
 
@@ -56,6 +69,10 @@ namespace ChatdollKit.Model
                     // Cache once regardless of UseCache to enable PreFetch
                     audioCache[voice.CacheKey] = clip;
                     audioDownloadTasks.Remove(voice.CacheKey);
+                    if (isDebug)
+                    {
+                        Debug.Log($"Return downloaded audio clip: {voice.CacheKey}");
+                    }
                     return clip;
                 }
                 else
@@ -97,7 +114,7 @@ namespace ChatdollKit.Model
             if (audioDownloadTasks.ContainsKey(voice.CacheKey))
             {
                 var task = audioDownloadTasks[voice.CacheKey];
-                if (task.GetAwaiter().IsCompleted)
+                if (!task.GetAwaiter().IsCompleted)
                 {
                     return true;
                 }


### PR DESCRIPTION
This bug causes multiple http requests for one voice request like below.

```bash
INFO:     127.0.0.1:60636 - "POST /audio_query?speaker=10&text=%e3%81%a9%e3%81%86%e3%81%97%e3%81%9f%e3%81%ae%ef%bc%9f HTTP/1.1" 200 OK
INFO:     127.0.0.1:60637 - "POST /audio_query?speaker=10&text=%e3%81%a9%e3%81%86%e3%81%97%e3%81%9f%e3%81%ae%ef%bc%9f HTTP/1.1" 200 OK
INFO:     127.0.0.1:60636 - "POST /synthesis?speaker=10 HTTP/1.1" 200 OK
INFO:     127.0.0.1:60637 - "POST /synthesis?speaker=10 HTTP/1.1" 200 OK
```