### PR TITLE
Make GetDialogToken public

### DIFF
--- a/Scripts/Dialog/DialogController.cs
+++ b/Scripts/Dialog/DialogController.cs
@@ -479,7 +479,7 @@ namespace ChatdollKit.Dialog
         }
 
         // Get cancellation token for tasks invoked in chat
-        private CancellationToken GetDialogToken()
+        public CancellationToken GetDialogToken()
         {
             // Create new TokenSource and return its token
             dialogTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
Allow getting CancellationToken from external programs to make tasks that can be canceled automatically when dialog starts.