### PR TITLE
Add support for ChatGPT function calling

### DIFF
--- a/Examples/ChatGPT/ChatGPTStreamSkill.cs
+++ b/Examples/ChatGPT/ChatGPTStreamSkill.cs
@@ -31,15 +31,41 @@ namespace ChatdollKit.Examples.ChatGPT
         public string Assistant1stShot;
         public int HistoryTurns = 10;
 
-        protected List<Dictionary<string, string>> histories = new List<Dictionary<string, string>>();
+        protected List<ChatGPTMessage> histories = new List<ChatGPTMessage>();
         protected ChatdollHttp client = new ChatdollHttp(timeout: 20000);
 
         private bool isResponseDone = false;
         private string streamBuffer;
+
+        protected enum ResponseType
+        {
+            None, Content, FunctionCalling
+        }
+        protected ResponseType responseType = ResponseType.None;
+        protected Delta firstDelta;
+
+        public List<ChatGPTFunction> ChatGPTFunctions = new List<ChatGPTFunction>();
+
         private List<AnimatedVoiceRequest> responseAnimations = new List<AnimatedVoiceRequest>();
 
         private void Start()
         {
+            // Functions
+            var functions = new ExampleFunctions();
+            var weatherFunction = new ChatGPTFunction("weather", "指定された地点の天気予報を調べます", functions.GetWeatherAsync);
+            weatherFunction.AddProperty("location", new Dictionary<string, object>()
+            {
+                { "type", "string" }
+            });
+            ChatGPTFunctions.Add(weatherFunction);
+
+            var balanceFunction = new ChatGPTFunction("get_balance", "銀行の残高を調べます", functions.GetBalanceAsync);
+            balanceFunction.AddProperty("bank_name", new Dictionary<string, object>()
+            {
+                { "type", "string" }
+            });
+            ChatGPTFunctions.Add(balanceFunction);
+
             // This is an example of the animation and face expression while processing request.
             // If you want make multi-skill virtual agent move this code to where common logic should be implemented like main app.
             var processingAnimation = new List<Model.Animation>();
@@ -83,67 +109,71 @@ namespace ChatdollKit.Examples.ChatGPT
                     histories.Clear();
                     if (!string.IsNullOrEmpty(User1stShot))
                     {
-                        histories.Add(new Dictionary<string, string>() {
-                            { "role", "user" },
-                            { "content", User1stShot }
-                        });
+                        histories.Add(new ChatGPTMessage("user", User1stShot));
                     }
                     if (!string.IsNullOrEmpty(Assistant1stShot))
                     {
-                        histories.Add(new Dictionary<string, string>() {
-                            { "role", "assistant" },
-                            { "content", Assistant1stShot }
-                        });
+                        histories.Add(new ChatGPTMessage("assistant", Assistant1stShot));
                     }
                 }
 
-                var messages = new List<Dictionary<string, string>>();
+                var messages = new List<ChatGPTMessage>();
 
                 // Condition
-                messages.Add(new Dictionary<string, string>() {
-                    { "role", "system" },
-                    { "content", ChatCondition.Replace("{now}", DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss")) }
-                });
+                messages.Add(new ChatGPTMessage(
+                    "system",
+                    ChatCondition.Replace("{now}", DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss")))
+                );
 
                 // Histories
                 messages.AddRange(histories.Skip(histories.Count - HistoryTurns * 2).ToList());
 
                 // Input
-                messages.Add(new Dictionary<string, string>() {
-                    { "role", "user" },
-                    { "content", request.Text }
-                });
-
-                // Make request data
-                var data = new Dictionary<string, object>()
-                {
-                    { "model", Model },
-                    { "max_tokens", MaxTokens },
-                    { "temperature", Temperature },
-                    { "messages", messages },
-                    { "stream", true },
-                };
-
-                // Prepare API request
-                var streamRequest = new UnityWebRequest("https://api.openai.com/v1/chat/completions", "POST");
-                streamRequest.SetRequestHeader("Authorization", "Bearer " + ApiKey);
-                streamRequest.SetRequestHeader("Content-Type", "application/json");
-                var bodyRaw = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
-                streamRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
-                streamRequest.downloadHandler = new ChatGPTStreamDownloadHandler();
-                ((ChatGPTStreamDownloadHandler)streamRequest.downloadHandler).DataCallbackFunc = (chunk) =>
-                {
-                    // Add received data to stream buffer
-                    streamBuffer += chunk;
-                };
+                messages.Add(new ChatGPTMessage("user", request.Text));
 
                 // Start API stream
-                isResponseDone = false;
-                streamBuffer = string.Empty;
-                var apiStreamTask = streamRequest.SendWebRequest();
+                var apiStreamTask = ChatCompletionAsync(messages);
 
                 // Start parsing and performing AnimatedVoice from buffer
                 responseAnimations.Clear();
+
+                // Wait for response type(content / function calling) set
+                while (responseType == ResponseType.None)
+                {
+                    await UniTask.Delay(10, cancellationToken: token);
+                }
+
+                // Function calling
+                if (responseType == ResponseType.FunctionCalling)
+                {
+                    var chatGptFunc = ChatGPTFunctions.Where(f => f.name == firstDelta.function_call.name).First();
+                    Debug.Log($"Invoke function: {chatGptFunc.name}");
+
+                    // TODO: Waiting AnimatedVoice
+
+                    await apiStreamTask;
+                    isResponseDone = true;
+
+                    var responseForRequest = await chatGptFunc.func.Invoke(streamBuffer, token);
+
+                    var function_call_message = new ChatGPTMessage("assistant", function_call: new Dictionary<string, object>() {
+                        { "name", chatGptFunc.name },
+                        { "arguments", streamBuffer }
+                    });
+
+                    // Update histories after function finishes successfully
+                    histories.Add(messages.Last());
+                    histories.Add(function_call_message);
+
+                    // Add messages
+                    messages.Add(function_call_message);
+                    messages.Add(new ChatGPTMessage("user", responseForRequest));
+
+                    // Call ChatCompletion to get human-friendly response
+                    apiStreamTask = ChatCompletionAsync(messages, false);
+                }
+
+                // Start parsing voices, faces and animations and performing them concurrently
                 var parseTask = ParseAnimatedVoiceAsync(token);
                 var performTask = PerformAnimatedVoiceAsync(token);
 
@@ -170,10 +200,10 @@ namespace ChatdollKit.Examples.ChatGPT
         {
             // Parse payloads
             var payloads = (Dictionary<string, object>)response.Payloads;
-            var apiStreamTask = (UnityWebRequestAsyncOperation)payloads["ApiStreamTask"];
+            var apiStreamTask = (UniTask)payloads["ApiStreamTask"];
             var parseTask = (UniTask)payloads["ParseTask"];
             var performTask = (UniTask)payloads["PerformTask"];
-            var userMessage = (Dictionary<string, string>)payloads["UserMessage"];
+            var userMessage = (ChatGPTMessage)payloads["UserMessage"];
 
             // Wait API stream ends
             await apiStreamTask;
@@ -185,13 +215,52 @@ namespace ChatdollKit.Examples.ChatGPT
 
             // Update histories
             histories.Add(userMessage);
-            histories.Add(new Dictionary<string, string>() {
-                { "role", "assistant" },
-                { "content", streamBuffer }
-            });
+            histories.Add(new ChatGPTMessage("assistant", streamBuffer));
         }
 
-        private async UniTask ParseAnimatedVoiceAsync(CancellationToken token)
+        protected async UniTask ChatCompletionAsync(List<ChatGPTMessage> messages, bool useFunctions = true)
+        {
+            // Make request data
+            var data = new Dictionary<string, object>()
+                {
+                    { "model", Model },
+                    { "max_tokens", MaxTokens },
+                    { "temperature", Temperature },
+                    { "messages", messages },
+                    { "stream", true },
+                };
+            if (useFunctions && ChatGPTFunctions.Count > 0)
+            {
+                data.Add("functions", ChatGPTFunctions);
+            }
+
+            // Prepare API request
+            using var streamRequest = new UnityWebRequest("https://api.openai.com/v1/chat/completions", "POST");
+            streamRequest.SetRequestHeader("Authorization", "Bearer " + ApiKey);
+            streamRequest.SetRequestHeader("Content-Type", "application/json");
+            var bodyRaw = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
+            streamRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
+            streamRequest.downloadHandler = new ChatGPTStreamDownloadHandler();
+            ((ChatGPTStreamDownloadHandler)streamRequest.downloadHandler).DataCallbackFunc = (chunk) =>
+            {
+                // Add received data to stream buffer
+                streamBuffer += chunk;
+            };
+            ((ChatGPTStreamDownloadHandler)streamRequest.downloadHandler).SetFirstDelta = (delta) =>
+            {
+                firstDelta = delta;
+                responseType = delta.function_call != null ? ResponseType.FunctionCalling : ResponseType.Content;
+            };
+
+            // Start API stream
+            isResponseDone = false;
+            streamBuffer = string.Empty;
+            responseType = ResponseType.None;
+            firstDelta = null;
+            await streamRequest.SendWebRequest();
+        }
+
+        protected async UniTask ParseAnimatedVoiceAsync(CancellationToken token)
         {
             var pattern = @"\[face:(.+?)\]";
             var splitIndex = 0;
@@ -251,7 +320,7 @@ namespace ChatdollKit.Examples.ChatGPT
             }
         }
 
-        private async UniTask PerformAnimatedVoiceAsync(CancellationToken token)
+        protected async UniTask PerformAnimatedVoiceAsync(CancellationToken token)
         {
             var isFirstVoice = true;
             while (!token.IsCancellationRequested)
@@ -286,9 +355,11 @@ namespace ChatdollKit.Examples.ChatGPT
             }
         }
 
-        public class ChatGPTStreamDownloadHandler : DownloadHandlerScript
+        protected class ChatGPTStreamDownloadHandler : DownloadHandlerScript
         {
             public Action<string> DataCallbackFunc;
+            public Action<Delta> SetFirstDelta;
+            private bool isDeltaSet = false;
 
             protected override bool ReceiveData(byte[] data, int dataLength)
             {
@@ -303,7 +374,20 @@ namespace ChatdollKit.Examples.ChatGPT
                     {
                         // Parse JSON and add content data to resp
                         var j = JsonConvert.DeserializeObject<ChatGPTStreamResponse>(d);
-                        resp += j.choices[0].delta.GetValueOrDefault("content");
+                        var delta = j.choices[0].delta;
+                        if (!isDeltaSet)
+                        {
+                            SetFirstDelta(delta);
+                            isDeltaSet = true;
+                        }
+                        if (delta.function_call == null)
+                        {
+                            resp += delta.content;
+                        }
+                        else
+                        {
+                            resp += delta.function_call.arguments;
+                        }
                     }
                 }
                 DataCallbackFunc?.Invoke(resp);
@@ -312,15 +396,79 @@ namespace ChatdollKit.Examples.ChatGPT
             }
         }
 
-        public class ChatGPTStreamResponse
+        protected class ChatGPTMessage
+        {
+            public string role { get; set; }
+            public string content { get; set; }
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public Dictionary<string, object> function_call { get; set; }
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public string name { get; set; }
+
+            public ChatGPTMessage(string role, string content = null, Dictionary<string, object> function_call = null, string name = null)
+            {
+                this.role = role;
+                this.content = content;
+                this.function_call = function_call;
+                this.name = name;
+            }
+        }
+
+        protected class ChatGPTStreamResponse
         {
             public string id { get; set; }
             public List<StreamChoice> choices { get; set; }
         }
 
-        public class StreamChoice
+        protected class StreamChoice
         {
-            public Dictionary<string, string> delta { get; set; }
+            public Delta delta { get; set; }
+        }
+
+        protected class Delta
+        {
+            public string content { get; set; }
+            public FunctionCall function_call { get; set; }
+        }
+
+        protected class FunctionCall
+        {
+            public string name { get; set; }
+            public string arguments { get; set; }
+        }
+
+        public class ChatGPTFunction
+        {
+            public string name { get; set; }
+            public string description { get; set; }
+            public ChatGPTFunctionParameters parameters;
+            [JsonIgnore]
+            public Func<string, CancellationToken, UniTask<string>> func;
+
+            public ChatGPTFunction(string name, string description, Func<string, CancellationToken, UniTask<string>> func)
+            {
+                this.name = name;
+                this.description = description;
+                parameters = new ChatGPTFunctionParameters();
+                this.func = func;
+            }
+
+            public void AddProperty(string key, Dictionary<string, object> value)
+            {
+                parameters.properties.Add(key, value);
+            }
+        }
+
+        public class ChatGPTFunctionParameters
+        {
+            public string type { get; set; }
+            public Dictionary<string, Dictionary<string, object>> properties;
+
+            public ChatGPTFunctionParameters()
+            {
+                type = "object";
+                properties = new Dictionary<string, Dictionary<string, object>>();
+            }
         }
     }
 }

--- a/Examples/ChatGPT/ExampleFunctions.cs
+++ b/Examples/ChatGPT/ExampleFunctions.cs
@@ -1,0 +1,129 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using ChatdollKit.Network;
+using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ChatdollKit.Examples.ChatGPT
+{
+    public class ExampleFunctions
+    {
+        private ChatdollHttp client = new ChatdollHttp(timeout: 20000);
+
+        public async UniTask<string> GetWeatherAsync(string jsonString, CancellationToken token)
+        {
+            var funcArgs = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonString);
+            var locationName = funcArgs["location"];
+
+            var locationCode = "130010";
+            if (locationName == "札幌")
+            {
+                locationCode = "016010";
+            }
+            else if (locationName == "仙台")
+            {
+                locationCode = "040010";
+            }
+            else if (locationName == "名古屋")
+            {
+                locationCode = "230010";
+            }
+            else if (locationName == "大阪")
+            {
+                locationCode = "270000";
+            }
+            else if (locationName == "広島")
+            {
+                locationCode = "340010";
+            }
+            else if (locationName == "福岡")
+            {
+                locationCode = "400010";
+            }
+            else if (locationName == "那覇")
+            {
+                locationCode = "471010";
+            }
+
+            // Get weather
+            var weatherResponse = await client.GetJsonAsync<WeatherResponse>($"https://weather.tsukumijima.net/api/forecast/city/{locationCode}", cancellationToken: token);
+
+            var ret = $"- 都市: {weatherResponse.location.city}\n- 天気: {weatherResponse.forecasts[0].telop}\n";
+
+            if (weatherResponse.forecasts[0].temperature.max.celsius != null)
+            {
+                ret += $"- 最高気温: {weatherResponse.forecasts[0].temperature.max.celsius}度";
+            }
+            else if (weatherResponse.forecasts[0].temperature.min.celsius != null)
+            {
+                ret += $"- 最低気温: {weatherResponse.forecasts[0].temperature.min.celsius}度";
+            }
+            else
+            {
+                ret += "- 気温: 情報なし";
+            }
+
+            return $"以下は天気予報の確認結果です。あなたの言葉でユーザーに伝えてください。\n\n\"\"\"{ret}\"\"\"";
+        }
+
+        private class WeatherResponse
+        {
+            public Location location;
+            public List<Forecast> forecasts;
+        }
+
+        private class Location
+        {
+            public string city;
+        }
+
+        private class Forecast
+        {
+            public string telop;
+            public Temperature temperature;
+        }
+
+        private class Temperature
+        {
+            public TemperatureItem max;
+            public TemperatureItem min;
+        }
+
+        private class TemperatureItem
+        {
+            public string celsius;
+        }
+
+        public async UniTask<string> GetBalanceAsync(string jsonString, CancellationToken token)
+        {
+            var funcArgs = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsonString);
+            var bank_name = funcArgs.GetValueOrDefault("bank_name");
+
+            var balances = new Dictionary<string, int>()
+            {
+                { "自由が丘銀行", 1234567 },
+                { "目黒銀行", 2345678 },
+                { "大岡山信金", 3456789 },
+            };
+
+            var ret = string.Empty;
+            if (string.IsNullOrEmpty(bank_name))
+            {
+                foreach (var b in balances)
+                {
+                    ret += $"- {b.Key}: {b.Value}\n";
+                }
+            }
+            else if (!balances.ContainsKey(bank_name))
+            {
+                ret = $"{bank_name}には預金口座がありません。";
+            }
+            else
+            {
+                ret = $"- {bank_name}: {balances[bank_name]}\n";
+            }
+
+            return $"以下は銀行預金残高の確認結果です。あなたの言葉でユーザーに伝えてください。\n\n\"\"\"{ret}\"\"\"";
+        }
+    }
+}

--- a/Examples/ChatGPT/ExampleFunctions.cs.meta
+++ b/Examples/ChatGPT/ExampleFunctions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d712e08433b05496aae22da844fc4ded
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add functions like below in `Start()`.
In this example, `GetWeatherAsync` will be invoked when `weather` is detected as function by ChatGPT. See also `ChatGPTStreamSkill.Start()`.

```csharp
// Define function
var weatherFunction = new ChatGPTFunction("weather", "指定された地点の天気予報を調べます", functions.GetWeatherAsync);
// Add properties to function
weatherFunction.AddProperty("location", new Dictionary<string, object>()
{
    { "type", "string" }
});
// Register function
ChatGPTFunctions.Add(weatherFunction);
```

And, here is the example of implementation of function. See also ExampleFunctions.cs.

```csharp
public async UniTask<string> DoSomethingAsync(string jsonString, CancellationToken token)
{
    // Parse arguments
    var funcArgs = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonString);

    // Do something

    // This message will be sent to ChatGPT again to convert human-friendly response
    return "Do something: success";
}
```