### PR TITLE
Fix bug that ChatGPT func is not registered

### DIFF
--- a/Scripts/Dialog/Processor/ChatGPTRouter.cs
+++ b/Scripts/Dialog/Processor/ChatGPTRouter.cs
@@ -36,7 +36,10 @@ namespace ChatdollKit.Dialog.Processor
             if (skill is ChatGPTFunctionSkillBase)
             {
                 var func = ((ChatGPTFunctionSkillBase)skill).GetFunctionSpec();
-                GetComponent<ChatGPTService>().AddFunction(func);
+                foreach (var gpt in GetComponents<ChatGPTService>())
+                {
+                    gpt.AddFunction(func);
+                }
                 functionResolver.Add(func.name, skill.TopicName);
             }
         }


### PR DESCRIPTION
ChatGPT func will not be registered when multiple ChatGPTServices (e.g. for App and for WebGL) are attached to the main components.