### PR TITLE
Make it possible to set role to the next message after function calling

### DIFF
--- a/Examples/ChatGPT/FunctionSkills/ReminderSkill.cs
+++ b/Examples/ChatGPT/FunctionSkills/ReminderSkill.cs
@@ -21,7 +21,7 @@ namespace ChatdollKit.Examples.ChatGPT
             return func;
         }
 
-        protected override async UniTask<string> ExecuteFunction(string argumentsJsonString, CancellationToken token)
+        protected override async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, CancellationToken token)
         {
             // Parse arguments
             var arguments = JsonConvert.DeserializeObject<Dictionary<string, string>>(argumentsJsonString);
@@ -36,7 +36,7 @@ namespace ChatdollKit.Examples.ChatGPT
             };
 
             // Return response as serialized JSON
-            return JsonConvert.SerializeObject(resp);
+            return new FunctionResponse(JsonConvert.SerializeObject(resp));
         }
     }
 }

--- a/Examples/ChatGPT/FunctionSkills/WeatherSkill.cs
+++ b/Examples/ChatGPT/FunctionSkills/WeatherSkill.cs
@@ -20,7 +20,7 @@ namespace ChatdollKit.Examples.ChatGPT
             return func;
         }
 
-        protected override async UniTask<string> ExecuteFunction(string argumentsJsonString, CancellationToken token)
+        protected override async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, CancellationToken token)
         {
             // Parse arguments
             var arguments = JsonConvert.DeserializeObject<Dictionary<string, string>>(argumentsJsonString);
@@ -35,7 +35,7 @@ namespace ChatdollKit.Examples.ChatGPT
             };
 
             // Return response as serialized JSON
-            return JsonConvert.SerializeObject(resp);
+            return new FunctionResponse(JsonConvert.SerializeObject(resp));
         }
     }
 }

--- a/Scripts/Dialog/Processor/ChatGPTFunctionSkillBase.cs
+++ b/Scripts/Dialog/Processor/ChatGPTFunctionSkillBase.cs
@@ -35,7 +35,7 @@ namespace ChatdollKit.Dialog.Processor
 
             // Add messages
             var messages = chatGPT.GetHistories(state);
-            messages.Add(new ChatGPTMessage("function", responseForRequest, name: functionName));
+            messages.Add(new ChatGPTMessage(responseForRequest.Role, responseForRequest.Body, name: functionName));
 
             // Call ChatCompletion to get human-friendly response
             apiStreamTask = chatGPT.ChatCompletionAsync(messages, false);
@@ -58,10 +58,22 @@ namespace ChatdollKit.Dialog.Processor
         }
 
 #pragma warning disable CS1998
-        protected virtual async UniTask<string> ExecuteFunction(string argumentsJsonString, CancellationToken token)
+        protected virtual async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, CancellationToken token)
         {
             throw new NotImplementedException("ChatGPTFunctionSkillBase.ExecuteFunction must be implemented");
         }
 #pragma warning restore CS1998
+
+        protected class FunctionResponse
+        {
+            public string Body { get; protected set; }
+            public string Role { get; protected set; }
+
+            public FunctionResponse(string body, string role = "function")
+            {
+                Body = body;
+                Role = role;
+            }
+        }
     }
 }


### PR DESCRIPTION
Return FunctionResponse with body if you want to send JSON serialized response from API to ChatGPT.

```CSharp
return new FunctionResponse(serializedJson);
```

Return FunctionResponse with body and role="user" if you want send content as user message to ChatGPT.

```CSharp
var data = JsonConvert.DeserializeObject(serializedJson);

return new FunctionResponse(
    $"Reply based on the following information:\n\n- {data.key1}\n- {data.key2}}",
    "user"
);
```