### PR TITLE
Add support for muting microphone

### DIFF
--- a/Scripts/IO/VoiceRecorderBase.cs
+++ b/Scripts/IO/VoiceRecorderBase.cs
@@ -46,11 +46,6 @@ namespace ChatdollKit.IO
 
             try
             {
-                if (!microphone.IsUpdatedOnThisFrame)
-                {
-                    return;
-                }
-
                 // Get captured data from microphone
                 var capturedData = microphone.CapturedData;
 


### PR DESCRIPTION
Stop capturing data from microphone when muted.
`UnityEngine.Microphone` ends internally.

```CSharp
var microphone = GetComponent<ChatdollMicrophone>();

// Mute
microphone.SetMute(true);

// Unmute
microphone.SetMute(false);

// Toggle
microphone.ToggleMute();
```

Also remove `ChatdollMicrophone.IsUpdateOnThisFrame` to detect silence to control recording session even no frame data comes from microphone.