### PR TITLE
Fix VoiceRecorder fails in starting

### DIFF
--- a/Scripts/IO/ChatdollMicrophone.cs
+++ b/Scripts/IO/ChatdollMicrophone.cs
@@ -188,6 +188,8 @@ namespace ChatdollKit.IO
             // Initialize data and status
             samplingData = new float[microphoneInput.samples * microphoneInput.channels];
             previousPosition = 0;
+            // Assure CapturedData.data is set when IsListening is true
+            CapturedData = new MicrophoneCapturedData(microphoneInput.channels, microphoneInput.frequency);
             IsListening = true;
         }
 

--- a/Scripts/IO/VoiceRecorderBase.cs
+++ b/Scripts/IO/VoiceRecorderBase.cs
@@ -39,7 +39,7 @@ namespace ChatdollKit.IO
         private void LateUpdate()
         {
             // Return if disabled or not listening
-            if (!IsEnabled || !IsListening)
+            if (!IsEnabled || !IsListening || !microphone.IsListening)
             {
                 return;
             }


### PR DESCRIPTION
Avoid this error by ensuring that microphone has `CapturedData.data` in `VoiceRecorderBase.LateUpdate()`.