### PR TITLE
Fix warning message when no skill router is attached

### DIFF
--- a/Scripts/Dialog/DialogController.cs
+++ b/Scripts/Dialog/DialogController.cs
@@ -173,6 +173,10 @@ namespace ChatdollKit.Dialog
                 {
                     // Create local request processor with components
                     Debug.Log("Use LocalRequestProcessor");
+                    if (skillRouter == null)
+                    {
+                        skillRouter = gameObject.AddComponent<StaticSkillRouter>();
+                    }
                     requestProcessor = new LocalRequestProcessor(
                         userStore, stateStore, skillRouter, skills
                     );


### PR DESCRIPTION
Attach StaticSkillRouter before new LocalRequestProcessor to avoid instantiate the router in processor.