### PR TITLE
Make it possible to use request, state and user info in ChatGPTFunctionSkills

### DIFF
--- a/Examples/ChatGPT/FunctionSkills/ReminderSkill.cs
+++ b/Examples/ChatGPT/FunctionSkills/ReminderSkill.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using UnityEngine;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
+using ChatdollKit.Dialog;
 using ChatdollKit.Dialog.Processor;
 
 namespace ChatdollKit.Examples.ChatGPT
@@ -21,7 +22,7 @@ namespace ChatdollKit.Examples.ChatGPT
             return func;
         }
 
-        protected override async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, CancellationToken token)
+        protected override async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, Request request, State state, User user, CancellationToken token)
         {
             // Parse arguments
             var arguments = JsonConvert.DeserializeObject<Dictionary<string, string>>(argumentsJsonString);

--- a/Examples/ChatGPT/FunctionSkills/WeatherSkill.cs
+++ b/Examples/ChatGPT/FunctionSkills/WeatherSkill.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using UnityEngine;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
+using ChatdollKit.Dialog;
 using ChatdollKit.Dialog.Processor;
 
 namespace ChatdollKit.Examples.ChatGPT
@@ -20,7 +21,7 @@ namespace ChatdollKit.Examples.ChatGPT
             return func;
         }
 
-        protected override async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, CancellationToken token)
+        protected override async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, Request request, State state, User user, CancellationToken token)
         {
             // Parse arguments
             var arguments = JsonConvert.DeserializeObject<Dictionary<string, string>>(argumentsJsonString);

--- a/Scripts/Dialog/Processor/ChatGPTFunctionSkillBase.cs
+++ b/Scripts/Dialog/Processor/ChatGPTFunctionSkillBase.cs
@@ -21,7 +21,7 @@ namespace ChatdollKit.Dialog.Processor
 
             await apiStreamTask;
 
-            var responseForRequest = await ExecuteFunction(chatGPT.StreamBuffer, token);
+            var responseForRequest = await ExecuteFunction(chatGPT.StreamBuffer, request, state, user, token);
 
             var functionName = GetFunctionSpec().name;
             var functionCallMessage = new ChatGPTMessage("assistant", function_call: new Dictionary<string, object>() {
@@ -58,7 +58,7 @@ namespace ChatdollKit.Dialog.Processor
         }
 
 #pragma warning disable CS1998
-        protected virtual async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, CancellationToken token)
+        protected virtual async UniTask<FunctionResponse> ExecuteFunction(string argumentsJsonString, Request request, State state, User user, CancellationToken token)
         {
             throw new NotImplementedException("ChatGPTFunctionSkillBase.ExecuteFunction must be implemented");
         }


### PR DESCRIPTION
Some use cases need these info. For example, Q&A skill needs request text.