### PR TITLE
Support azure openai service

### DIFF
--- a/Plugins/ChatGPTServiceWebGL.jslib
+++ b/Plugins/ChatGPTServiceWebGL.jslib
@@ -1,14 +1,16 @@
 mergeInto(LibraryManager.library, {
-    ChatCompletionJS: function(targetObjectNamePtr, apiKeyPtr, chatCompletionRequestPtr) {
+    ChatCompletionJS: function(targetObjectNamePtr, urlPtr, apiKeyPtr, chatCompletionRequestPtr) {
         let targetObjectName = UTF8ToString(targetObjectNamePtr);
+        let url = UTF8ToString(urlPtr);
         let apiKey = UTF8ToString(apiKeyPtr);
         let chatCompletionRequest = UTF8ToString(chatCompletionRequestPtr);
         let decoder = new TextDecoder("utf-8");
 
-        fetch("https://api.openai.com/v1/chat/completions", {
+        fetch(url, {
             headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${apiKey}`
+                "Authorization": `Bearer ${apiKey}`,
+                "api-key": `${apiKey}`
             },
             method: "POST",
             body: chatCompletionRequest

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,7 +17,7 @@ ChatdollKitは、お好みの3Dモデルを使って音声対話可能なチャ�
     - 音声認識・テキスト読み上げ（Text-to-Speech。Azure、Google、Watson、VOICEROID、VOICEVOX等）
     - 対話の文脈・ステート管理
     - 発話意図の抽出と対話トピックのルーティング
-    - ChatGPT対応とその感情シミュレーションサンプル
+    - ChatGPT / Azure OpenAI Service対応（表情の自律制御も可能）
 
 - 入出力
     - ウェイクワードによる起動
@@ -125,6 +125,23 @@ UnityのPlayボタンを押します。3Dモデルがまばたきをしながら
 - 話しかけた言葉と同じ内容を応答
 
 <img src="Documents/Images/run.png" width="640">
+
+
+# 🌊 Use Azure OpenAI Service
+
+Azure OpenAI Serviceを利用するには、ChatGPTServiceコンポーネントのインスペクター上で以下の通り設定してください。
+
+1. 設定情報を含むエンドポイントURLを`Chat Completion Url`に設定
+```
+format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}
+```
+
+2. API Keyを`Api Key`に設定
+
+3. `Is Azure`にチェックを入れる
+
+NOTE: インスペクターで設定した`Model`は無視され、URLに含まれているモデルが使用されます。
+
 
 
 # 👷‍♀️ カスタムアプリケーションの作り方

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     - Speech-to-Text and Text-to-Speech (Azure, Google, Watson etc)
     - Dialog state management
     - Intent extraction and topic routing
-    - ChatGPT with emotion engine
+    - ChatGPT / Azure OpenAI Service (with autonomous face expression)
 
 - I/O
     - Wakeword
@@ -127,6 +127,22 @@ Press Play button of Unity editor. You can see the model starts with idling anim
 - Your model will reply "Hello world"
 
 <img src="Documents/Images/run.png" width="640">
+
+
+# 🌊 Use Azure OpenAI Service
+
+To use Azure OpenAI Service set following info on inspector of ChatGPTService component:
+
+1. Endpoint url with configurations to `Chat Completion Url`
+```
+format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}
+```
+
+2. API Key to `Api Key`
+
+3. Set true to `Is Azure`
+
+NOTE: `Model` on inspector is ignored. Engine in url is used.
 
 
 # 👷‍♀️ Build your own app

--- a/Scripts/Dialog/Processor/ChatGPTServiceWebGL.cs
+++ b/Scripts/Dialog/Processor/ChatGPTServiceWebGL.cs
@@ -9,7 +9,7 @@ namespace ChatdollKit.Dialog.Processor
     public class ChatGPTServiceWebGL : ChatGPTService
     {
         [DllImport("__Internal")]
-        private static extern void ChatCompletionJS(string targetObjectName, string apiKey, string chatCompletionRequest);
+        private static extern void ChatCompletionJS(string targetObjectName, string url, string apiKey, string chatCompletionRequest);
 
         public int TimeoutMilliseconds = 60000;
 
@@ -37,7 +37,7 @@ namespace ChatdollKit.Dialog.Processor
             StreamBuffer = string.Empty;
             responseType = ResponseType.None;
             firstDelta = null;
-            ChatCompletionJS(gameObject.name, ApiKey, JsonConvert.SerializeObject(data));
+            ChatCompletionJS(gameObject.name, ChatCompletionUrl, ApiKey, JsonConvert.SerializeObject(data));
 
             var startAt = System.DateTime.UtcNow.Ticks;
             while (!IsResponseDone)


### PR DESCRIPTION
# 🌊 Use Azure OpenAI Service

To use Azure OpenAI Service set following info on inspector of ChatGPTService component:

1. Endpoint url with configurations to `Chat Completion Url`
```
format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version={api-version}
```

2. API Key to `Api Key`

3. Set true to `Is Azure`

NOTE: `Model` on inspector is ignored. Engine in url is used.
