### PR TITLE
Add support for OpenAI Speech Services

### DIFF
--- a/Demo/DemoChatGPT.unity
+++ b/Demo/DemoChatGPT.unity
@@ -673,7 +673,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ApiKey: 
-  Model: gpt-3.5-turbo-0613
+  Model: gpt-3.5-turbo-1106
+  ChatCompletionUrl: 
+  IsAzure: 0
   MaxTokens: 0
   Temperature: 0.5
   SystemMessageContent: '* You are my sister. We are very close and we speak in a
@@ -691,6 +693,89 @@ MonoBehaviour:
     [face:Joy]Hey,
     you can see the ocean! [face:Fun]Let''s go swimming.'
   HistoryTurns: 10
+  DebugMode: 0
+--- !u!114 &2893757555470248022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2893757555470248016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1436aab79be70429b9891c1481f6841a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IsEnabled: 0
+  AutoStart: 1
+  PrintResult: 0
+  VoiceDetectionThreshold: 0.1
+  VoiceDetectionRaisedThreshold: 0.5
+  VoiceDetectionMinimumLength: 0.2
+  SilenceDurationToEndRecording: 0.3
+  VoiceRecognitionMaximumLength: 3
+  WakeWords: []
+  CancelWords: []
+  IgnoreWords:
+  - "\u3002"
+  - "\u3001"
+  - "\uFF1F"
+  - "\uFF01"
+  ApiKey: 
+  Model: whisper-1
+  Language: 
+  Prompt: 
+  Temperature: 0
+--- !u!114 &2893757555470248023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2893757555470248016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00c0e9781e80d44ddbc90fa3ec6fb838, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IsEnabled: 0
+  CancelWords: []
+  IgnoreWords:
+  - "\u3002"
+  - "\u3001"
+  - "\uFF1F"
+  - "\uFF01"
+  PrintResult: 0
+  VoiceDetectionThreshold: 0.1
+  VoiceDetectionMinimumLength: 0.3
+  SilenceDurationToEndRecording: 1
+  ListeningTimeout: 20
+  MessageWindow: {fileID: 0}
+  listeningMessage: '[ Listening ... ]'
+  ApiKey: 
+  Model: whisper-1
+  Language: 
+  Prompt: 
+  Temperature: 0
+--- !u!114 &2893757555470248024
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2893757555470248016}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f9ddc79bad1e48e58ab63dcb3343871, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Timeout: 10
+  isDebug: 0
+  _Name: OpenAI
+  _IsDefault: 1
+  ApiKey: 
+  Voice: nova
+  Speed: 1
 --- !u!1001 &4623211973538491283
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -746,7 +831,7 @@ PrefabInstance:
     - target: {fileID: 7494064416744276939, guid: 9923f5ee8d02c4f658216c52051a0d17,
         type: 3}
       propertyPath: SpeechService
-      value: 0
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7494064416744276942, guid: 9923f5ee8d02c4f658216c52051a0d17,
         type: 3}

--- a/Demo/DemoVRMLoader.unity
+++ b/Demo/DemoVRMLoader.unity
@@ -416,40 +416,13 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0.767, y: 172.77802, z: 0}
---- !u!1 &2893757555470248016 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7494064416744276931, guid: 9923f5ee8d02c4f658216c52051a0d17,
-    type: 3}
-  m_PrefabInstance: {fileID: 4623211973538491283}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &2893757555470248017
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2893757555470248016}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c272f4a00ee954d90be7053bd01902f2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Name: 
-  ApiKey: 
-  Model: gpt-3.5-turbo
-  MaxTokens: 2000
-  Temperature: 0.5
-  ChatCondition: You are my sister. We are very close and we speak in a casual manner.
-  User1stShot: 
-  Assistant1stShot: 
-  HistoryTurns: 10
 --- !u!114 &2893757555470248029 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7494064416744276981, guid: 9923f5ee8d02c4f658216c52051a0d17,
     type: 3}
   m_PrefabInstance: {fileID: 4623211973538491283}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2893757555470248016}
+  m_GameObject: {fileID: 4623211973538491286}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dbe823670680445ab88dfd996ec87ed2, type: 3}
@@ -499,8 +472,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7494064416744276939, guid: 9923f5ee8d02c4f658216c52051a0d17,
         type: 3}
+      propertyPath: OpenAIApiKey
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7494064416744276939, guid: 9923f5ee8d02c4f658216c52051a0d17,
+        type: 3}
       propertyPath: SpeechService
-      value: 0
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7494064416744276942, guid: 9923f5ee8d02c4f658216c52051a0d17,
         type: 3}
@@ -613,3 +591,137 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 28a8b05cb2dee4dd0b7cf4e76975f88a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &4623211973538491286 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7494064416744276931, guid: 9923f5ee8d02c4f658216c52051a0d17,
+    type: 3}
+  m_PrefabInstance: {fileID: 4623211973538491283}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4623211973538491287
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4623211973538491286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1436aab79be70429b9891c1481f6841a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IsEnabled: 0
+  AutoStart: 1
+  PrintResult: 0
+  VoiceDetectionThreshold: 0.1
+  VoiceDetectionRaisedThreshold: 0.5
+  VoiceDetectionMinimumLength: 0.2
+  SilenceDurationToEndRecording: 0.3
+  VoiceRecognitionMaximumLength: 3
+  WakeWords: []
+  CancelWords: []
+  IgnoreWords:
+  - "\u3002"
+  - "\u3001"
+  - "\uFF1F"
+  - "\uFF01"
+  ApiKey: 
+  Model: whisper-1
+  Language: 
+  Prompt: 
+  Temperature: 0
+--- !u!114 &4623211973538491288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4623211973538491286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00c0e9781e80d44ddbc90fa3ec6fb838, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  IsEnabled: 0
+  CancelWords: []
+  IgnoreWords:
+  - "\u3002"
+  - "\u3001"
+  - "\uFF1F"
+  - "\uFF01"
+  PrintResult: 0
+  VoiceDetectionThreshold: 0.1
+  VoiceDetectionMinimumLength: 0.3
+  SilenceDurationToEndRecording: 1
+  ListeningTimeout: 20
+  MessageWindow: {fileID: 0}
+  listeningMessage: '[ Listening ... ]'
+  ApiKey: 
+  Model: whisper-1
+  Language: 
+  Prompt: 
+  Temperature: 0
+--- !u!114 &4623211973538491289
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4623211973538491286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f9ddc79bad1e48e58ab63dcb3343871, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Timeout: 10
+  isDebug: 0
+  _Name: OpenAI
+  _IsDefault: 1
+  ApiKey: 
+  Voice: nova
+  Speed: 1
+--- !u!114 &4623211973538491290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4623211973538491286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de7f2181f3b3b496ba86968cc312f11f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: 
+--- !u!114 &4623211973538491291
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4623211973538491286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c9853557e2b74d8d947619144de2315, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4623211973538491292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4623211973538491286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 124166487f788420998c172570993898, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ApiKey: 
+  Model: gpt-3.5-turbo-1106
+  ChatCompletionUrl: 
+  IsAzure: 0
+  MaxTokens: 0
+  Temperature: 0.5
+  SystemMessageContent: 
+  HistoryTurns: 10
+  DebugMode: 0

--- a/Editor/ChatdollKitEditor.cs
+++ b/Editor/ChatdollKitEditor.cs
@@ -6,6 +6,7 @@ using ChatdollKit.IO;
 using ChatdollKit.Model;
 using ChatdollKit.Extension.Azure;
 using ChatdollKit.Extension.Google;
+using ChatdollKit.Extension.OpenAI;
 using ChatdollKit.Extension.Watson;
 
 namespace ChatdollKit
@@ -103,6 +104,12 @@ namespace ChatdollKit
                     voiceRequestProvider = app.gameObject.GetComponent<GoogleVoiceRequestProvider>() ?? app.gameObject.AddComponent<GoogleVoiceRequestProvider>();
                     wakeWordListener = app.gameObject.GetComponent<GoogleWakeWordListener>() ?? app.gameObject.AddComponent<GoogleWakeWordListener>();
                 }
+                else if (app.SpeechService == CloudService.OpenAI)
+                {
+                    ttsLoader = app.gameObject.GetComponent<OpenAITTSLoader>() ?? app.gameObject.AddComponent<OpenAITTSLoader>();
+                    voiceRequestProvider = app.gameObject.GetComponent<OpenAIVoiceRequestProvider>() ?? app.gameObject.AddComponent<OpenAIVoiceRequestProvider>();
+                    wakeWordListener = app.gameObject.GetComponent<OpenAIWakeWordListener>() ?? app.gameObject.AddComponent<OpenAIWakeWordListener>();
+                }
                 else if (app.SpeechService == CloudService.Watson)
                 {
                     ttsLoader = app.gameObject.GetComponent<WatsonTTSLoader>() ?? app.gameObject.AddComponent<WatsonTTSLoader>();
@@ -149,6 +156,24 @@ namespace ChatdollKit
                     ttsLoader.Configure(app.GoogleApiKey, app.GoogleLanguage, app.GoogleGender, app.GoogleSpeakerName, true);
                     voiceRequestProvider.Configure(app.GoogleApiKey, app.GoogleLanguage, true);
                     wakeWordListener.Configure(app.GoogleApiKey, app.GoogleLanguage, true);
+
+                    EditorUtility.SetDirty(app);
+                }
+            }
+            else if (app.SpeechService == CloudService.OpenAI)
+            {
+                EditorGUI.BeginChangeCheck();
+                app.OpenAIApiKey = EditorGUILayout.TextField("API Key", app.OpenAIApiKey);
+                app.OpenAILanguage = EditorGUILayout.TextField("Language", app.OpenAILanguage);
+                app.OpenAIVoice = EditorGUILayout.TextField("Voice", app.OpenAIVoice);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    var ttsLoader = app.gameObject.GetComponent<OpenAITTSLoader>() ?? app.gameObject.AddComponent<OpenAITTSLoader>();
+                    var voiceRequestProvider = app.gameObject.GetComponent<OpenAIVoiceRequestProvider>() ?? app.gameObject.AddComponent<OpenAIVoiceRequestProvider>();
+                    var wakeWordListener = app.gameObject.GetComponent<OpenAIWakeWordListener>() ?? app.gameObject.AddComponent<OpenAIWakeWordListener>();
+                    ttsLoader.Configure(app.OpenAIApiKey, app.OpenAIVoice, true);
+                    voiceRequestProvider.Configure(app.OpenAIApiKey, app.OpenAILanguage, true);
+                    wakeWordListener.Configure(app.OpenAIApiKey, app.OpenAILanguage, true);
 
                     EditorUtility.SetDirty(app);
                 }

--- a/Extension/OpenAI.meta
+++ b/Extension/OpenAI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 062ff5d9112284e1ea72b3b7ed075faa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Extension/OpenAI/OpenAITTSLoader.cs
+++ b/Extension/OpenAI/OpenAITTSLoader.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Networking;
+using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
+using ChatdollKit.Model;
+using ChatdollKit.IO;
+
+namespace ChatdollKit.Extension.OpenAI
+{
+    public class OpenAITTSLoader : WebVoiceLoaderBase
+    {
+        public override VoiceLoaderType Type { get; } = VoiceLoaderType.TTS;
+        public string _Name = "OpenAI";
+        public override string Name
+        {
+            get
+            {
+                return _Name;
+            }
+        }
+        public bool _IsDefault = true;
+        public override bool IsDefault
+        {
+            get
+            {
+                return _IsDefault;
+            }
+            set
+            {
+                _IsDefault = value;
+            }
+        }
+
+        public string ApiKey;
+        public string Voice = "nova";
+        public float Speed = 1.0f;
+
+        public void Configure(string apiKey, string voice, bool overwrite = false)
+        {
+            ApiKey = string.IsNullOrEmpty(ApiKey) || overwrite ? apiKey : ApiKey;
+            Voice = string.IsNullOrEmpty(Voice) || overwrite ? voice : Voice;
+        }
+
+        // See API document: https://platform.openai.com/docs/api-reference/audio/createSpeech
+        protected override async UniTask<AudioClip> DownloadAudioClipAsync(Voice voice, CancellationToken token)
+        {
+            if (token.IsCancellationRequested) { return null; };
+
+            var headers = new Dictionary<string, string>()
+            {
+                { "Authorization", $"Bearer {ApiKey}"  },
+                { "Content-Type", "application/json" }
+            };
+
+            var data = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new Dictionary<string, object>() {
+                { "model", "tts-1" },
+                { "input", voice.Text },
+                { "voice", Voice },
+                { "response_format", "mp3" },   // opus, aac and flac is not supported by Unity
+                { "speed", Speed }
+            }));
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return await DownloadAudioClipWebGLAsync("https://api.openai.com/v1/audio/speech", data, headers, token);
+#else
+            return await DownloadAudioClipNativeAsync("https://api.openai.com/v1/audio/speech", data, headers, token);
+#endif
+        }
+
+        protected async UniTask<AudioClip> DownloadAudioClipNativeAsync(string url, byte[] data, Dictionary<string, string> headers, CancellationToken token)
+        {
+            using (var www = UnityWebRequestMultimedia.GetAudioClip(url, AudioType.MPEG))
+            {
+                www.timeout = Timeout;
+                www.method = "POST";
+
+                www.SetRequestHeader("Authorization", headers["Authorization"]);
+                www.SetRequestHeader("Content-Type", headers["Content-Type"]);
+
+                www.uploadHandler = new UploadHandlerRaw(data);
+
+                await www.SendWebRequest().ToUniTask();
+
+                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
+                {
+                    Debug.LogError($"Error occured while processing text-to-speech voice: {www.error}");
+                }
+                else if (www.isDone)
+                {
+                    return DownloadHandlerAudioClip.GetContent(www);
+                }
+            }
+            return null;
+        }
+
+        protected async UniTask<AudioClip> DownloadAudioClipWebGLAsync(string url, byte[] data, Dictionary<string, string> headers, CancellationToken token)
+        {
+            Debug.LogWarning("Unity doesn't support playback MP3 on WebGL.");
+
+            var resp = await client.PostBytesAsync(url, data, headers, cancellationToken: token);
+            return AudioConverter.PCMToAudioClip(resp.Data, 1, 8000);
+        }
+    }
+}

--- a/Extension/OpenAI/OpenAITTSLoader.cs.meta
+++ b/Extension/OpenAI/OpenAITTSLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f9ddc79bad1e48e58ab63dcb3343871
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Extension/OpenAI/OpenAIVoiceRequestProvider.cs
+++ b/Extension/OpenAI/OpenAIVoiceRequestProvider.cs
@@ -1,0 +1,60 @@
+using System;
+using UnityEngine;
+using UnityEngine.Networking;
+using Cysharp.Threading.Tasks;
+using ChatdollKit.Dialog;
+using ChatdollKit.IO;
+
+namespace ChatdollKit.Extension.OpenAI
+{
+    public class OpenAIVoiceRequestProvider : VoiceRequestProviderBase
+    {
+        [Header("OpenAI Settings")]
+        public string ApiKey;
+        public string Model = "whisper-1";
+        public string Language;
+        public string Prompt;
+        public float Temperature = 0.0f;
+
+        public void Configure(string apiKey, string language, bool overwrite = false)
+        {
+            ApiKey = string.IsNullOrEmpty(ApiKey) || overwrite ? apiKey : ApiKey;
+            Language = string.IsNullOrEmpty(Language) || overwrite ? language : Language;
+        }
+
+        // See API document: https://platform.openai.com/docs/api-reference/audio/createTranscription
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
+        {
+            var form = new WWWForm();
+            form.AddField("model", "whisper-1");
+            if (!string.IsNullOrEmpty(Language))
+            {
+                form.AddField("language", Language);
+            }
+            form.AddField("response_format", "text");
+            form.AddBinaryData("file", AudioConverter.AudioClipToPCM(recordedVoice.Voice, recordedVoice.SamplingData), "voice.wav"); // filename is required to transcribe
+            if (!string.IsNullOrEmpty(Prompt))
+            {
+                form.AddField("prompt", Prompt);
+            }
+            form.AddField("temperature", Temperature.ToString());
+
+            using (UnityWebRequest request = UnityWebRequest.Post("https://api.openai.com/v1/audio/transcriptions", form))
+            {
+                request.SetRequestHeader("Authorization", $"Bearer {ApiKey}");
+
+                try
+                {
+                    await request.SendWebRequest().ToUniTask();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error at SendWebRequest() to POST https://api.openai.com/v1/audio/transcriptions: {ex.Message}\n{ex.StackTrace}");
+                    throw ex;
+                }
+
+                return request.downloadHandler.text;
+            }
+        }
+    }
+}

--- a/Extension/OpenAI/OpenAIVoiceRequestProvider.cs.meta
+++ b/Extension/OpenAI/OpenAIVoiceRequestProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00c0e9781e80d44ddbc90fa3ec6fb838
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Extension/OpenAI/OpenAIWakeWordListener.cs
+++ b/Extension/OpenAI/OpenAIWakeWordListener.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.Networking;
+using Cysharp.Threading.Tasks;
+using ChatdollKit.Dialog;
+using ChatdollKit.IO;
+
+namespace ChatdollKit.Extension.OpenAI
+{
+    public class OpenAIWakeWordListener : WakeWordListenerBase
+    {
+        [Header("OpenAI Settings")]
+        public string ApiKey;
+        public string Model = "whisper-1";
+        public string Language;
+        public string Prompt;
+        public float Temperature = 0.0f;
+
+        public void Configure(string apiKey, string language, bool overwrite = false)
+        {
+            ApiKey = string.IsNullOrEmpty(ApiKey) || overwrite ? apiKey : ApiKey;
+            Language = string.IsNullOrEmpty(Language) || overwrite ? language : Language;
+        }
+
+        // See API document: https://platform.openai.com/docs/api-reference/audio/createTranscription
+        protected override async UniTask<string> RecognizeSpeechAsync(VoiceRecorderResponse recordedVoice)
+        {
+            var form = new WWWForm();
+            form.AddField("model", "whisper-1");
+            if (!string.IsNullOrEmpty(Language))
+            {
+                form.AddField("language", Language);
+            }
+            form.AddField("response_format", "text");
+            form.AddBinaryData("file", AudioConverter.AudioClipToPCM(recordedVoice.Voice, recordedVoice.SamplingData), "voice.wav"); // filename is required to transcribe
+            if (!string.IsNullOrEmpty(Prompt))
+            {
+                form.AddField("prompt", Prompt);
+            }
+            form.AddField("temperature", Temperature.ToString());
+
+            using (UnityWebRequest request = UnityWebRequest.Post("https://api.openai.com/v1/audio/transcriptions", form))
+            {
+                request.SetRequestHeader("Authorization", $"Bearer {ApiKey}");
+
+                try
+                {
+                    await request.SendWebRequest().ToUniTask();
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error at SendWebRequest() to POST https://api.openai.com/v1/audio/transcriptions: {ex.Message}\n{ex.StackTrace}");
+                    throw ex;
+                }
+
+                return request.downloadHandler.text;
+            }
+        }
+    }
+}

--- a/Extension/OpenAI/OpenAIWakeWordListener.cs.meta
+++ b/Extension/OpenAI/OpenAIWakeWordListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1436aab79be70429b9891c1481f6841a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@ ChatdollKitは、お好みの3Dモデルを使って音声対話可能なチャ�
     - まばたきと口パク
 
 - 対話制御
-    - 音声認識・テキスト読み上げ（Text-to-Speech。Azure、Google、Watson、VOICEROID、VOICEVOX等）
+    - 音声認識・テキスト読み上げ（OpenAI、Azure、Google、Watson、VOICEROID、VOICEVOX等）
     - 対話の文脈・ステート管理
     - 発話意図の抽出と対話トピックのルーティング
     - ChatGPT / Azure OpenAI Service対応（表情の自律制御も可能）
@@ -92,7 +92,7 @@ ModelControllerのコンテキストメニューから `Setup Animator` を選�
 
 ## 🍣 ChatdollKit
 
-`ChatdollKit`のインスペクター上で音声認識・読み上げサービス（Azure/Google/Watson）を選択し、APIキーなど必要な情報を入力してください。
+`ChatdollKit`のインスペクター上で音声認識・読み上げサービス（OpenAI/Azure/Google/Watson）を選択し、APIキーなど必要な情報を入力してください。
 
 <img src="Documents/Images/chatdollkit.png" width="640">
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     - Blink and lipsync
 
 - Dialog
-    - Speech-to-Text and Text-to-Speech (Azure, Google, Watson etc)
+    - Speech-to-Text and Text-to-Speech (OpenAI, Azure, Google, Watson, VOICEVOX, VOICEROID etc)
     - Dialog state management
     - Intent extraction and topic routing
     - ChatGPT / Azure OpenAI Service (with autonomous face expression)
@@ -94,7 +94,7 @@ On the inspector of `DialogController`, set `Wake Word` to start conversation (e
 
 ## 🍣 ChatdollKit
 
-Select the speech service (Azure/Google/Watson) you use and set API key and some properties like Region and BaseUrl on inspector of ChatdollKit.
+Select the speech service (OpenAI/Azure/Google/Watson) you use and set API key and some properties like Region and BaseUrl on inspector of ChatdollKit.
 
 <img src="Documents/Images/chatdollkit.png" width="640">
 

--- a/Scripts/ChatdollKit.cs
+++ b/Scripts/ChatdollKit.cs
@@ -12,7 +12,8 @@ namespace ChatdollKit
         Other,
         Azure,
         Google,
-        Watson
+        Watson,
+        OpenAI
     }
 
     [RequireComponent(typeof(ModelController))]
@@ -37,6 +38,11 @@ namespace ChatdollKit
         [HideInInspector] public string GoogleLanguage = "ja-JP";
         [HideInInspector] public string GoogleGender = "FEMALE";
         [HideInInspector] public string GoogleSpeakerName = "ja-JP-Standard-A";
+
+        // OpenAI
+        [HideInInspector] public string OpenAIApiKey = string.Empty;
+        [HideInInspector] public string OpenAILanguage = string.Empty;
+        [HideInInspector] public string OpenAIVoice = "nova";
 
         // Watson
         [HideInInspector] public string WatsonTTSApiKey = string.Empty;


### PR DESCRIPTION
Select OpenAI in the Speech Service section of the ChatdollKit inspector and configure the API key and other settings.
Alternatively, you can attach and configure the components individually.

- Text-to-Speech: OpenAITTSLoader
- Speech Recognition: OpenAIVoiceRequestProvider and OpenAIWakewordListener