### PR TITLE
Add support for stream speech recognition

### DIFF
--- a/Extension/Azure/AzureStreamVoiceRequestProvider.cs
+++ b/Extension/Azure/AzureStreamVoiceRequestProvider.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Threading;
+using UnityEngine;
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+using Cysharp.Threading.Tasks;
+using ChatdollKit.Dialog;
+
+namespace ChatdollKit.Extension.Azure
+{
+    public class AzureStreamVoiceRequestProvider : VoiceRequestProviderBase
+    {
+        [Header("Azure Settings")]
+        public string ApiKey;
+        public string Region;
+        public string Language = "ja-JP";
+
+        private AudioConfig audioConfig;
+        private SpeechConfig speechConfig;
+        private SpeechRecognizer recognizer;
+        private string recognizedTextBuffer;
+        private bool isRecognizing;
+
+        public async UniTask StartRecognitionAsync()
+        {
+            // Initialize recognizer
+            audioConfig = AudioConfig.FromDefaultMicrophoneInput();
+            speechConfig = SpeechConfig.FromSubscription(ApiKey, Region);
+            if (!string.IsNullOrEmpty(Language))
+            {
+                speechConfig.SpeechRecognitionLanguage = Language;
+            }
+            speechConfig.SetProperty(
+                PropertyId.Speech_SegmentationSilenceTimeoutMs,
+                ((int)(SilenceDurationToEndRecording * 1000)).ToString()
+            );
+            speechConfig.SetProperty(
+                PropertyId.Conversation_Initial_Silence_Timeout,
+                ((int)(ListeningTimeout * 1000)).ToString()
+            );
+
+            recognizer = new SpeechRecognizer(speechConfig, audioConfig);
+            recognizer.Recognizing += (sender, e) =>
+            {
+                recognizedTextBuffer = e.Result.Text;
+            };
+            recognizer.Recognized += (sender, e) =>
+            {
+                _ = StopRecognitionAsync();
+                recognizedTextBuffer = e.Result.Text;
+                if (PrintResult)
+                {
+                    Debug.Log($"Recognized(VoiceRequestProvider): {recognizedTextBuffer}");
+                }
+            };
+
+            // Start recognizing
+            recognizedTextBuffer = string.Empty;
+            await recognizer.StartContinuousRecognitionAsync();
+            isRecognizing = true;
+
+            Debug.Log("Speech recognition started");
+        }
+
+        public async UniTask StopRecognitionAsync()
+        {
+            if (recognizer != null)
+            {
+                try
+                {
+                    await recognizer.StopContinuousRecognitionAsync();
+                    recognizer.Dispose();
+                    Debug.Log("Speech recognition stopped");
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Do nothing
+                }
+            }
+
+            isRecognizing = false;
+        }
+
+        public override async UniTask<Request> GetRequestAsync(CancellationToken token)
+        {
+            var request = new Request(RequestType);
+
+            try
+            {
+                // Update RecognitionId
+                var currentRecognitionId = Guid.NewGuid().ToString();
+                recognitionId = currentRecognitionId;
+
+                // Invoke action before start recognition
+                await (OnStartListeningAsync ?? OnStartListeningDefaultAsync).Invoke(request, token);
+
+                // Start
+                await StartRecognitionAsync();
+                _ = ((SimpleMessageWindow)MessageWindow).SetMessageStreamAsync(() => {
+                    return new StreamMessageRequest() { Text = recognizedTextBuffer, IsEnd = !isRecognizing };
+                }, token);
+
+                while (isRecognizing)
+                {
+                    if (!string.IsNullOrEmpty(TextInput))
+                    {
+                        await StopRecognitionAsync();
+                        recognizedTextBuffer = TextInput;
+                        TextInput = string.Empty;
+                    }
+
+                    await UniTask.Delay(50, cancellationToken: token);
+                }
+
+                // Exit if RecognitionId is updated by another request
+                if (recognitionId != currentRecognitionId)
+                {
+                    Debug.Log($"Id was updated by another request: Current {currentRecognitionId} / Global {recognitionId}");
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(recognizedTextBuffer))
+                    {
+                        request.Text = recognizedTextBuffer;
+                        if (PrintResult)
+                        {
+                            Debug.Log($"Recognized(VoiceRequestProvider): {request.Text}");
+                        }
+                    }
+                }
+
+                if (!request.IsSet())
+                {
+                    Debug.LogWarning("No speech recognized");
+                }
+
+                // Clean up to check cancel
+                var text = request.Text;
+                foreach (var iw in IgnoreWords)
+                {
+                    text = text.Replace(iw, string.Empty);
+                }
+
+                // Check cancellation
+                if (CancelWords.Contains(text))
+                {
+                    Debug.LogWarning("Request canceled");
+                    request.IsCanceled = true;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                Debug.Log("Canceled during recognizing speech");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Error occured in recognizing speech: {ex.Message}\n{ex.StackTrace}");
+                await OnErrorAsync(request, token);
+            }
+            finally
+            {
+                StopListening();
+                // Invoke action after recognition
+                await (OnFinishListeningAsync ?? OnFinishListeningDefaultAsync).Invoke(request, token);
+            }
+
+            return request;
+        }
+
+#pragma warning disable CS1998
+        protected override async UniTask OnFinishListeningDefaultAsync(Request request, CancellationToken token)
+        {
+            // Do nothing (In default settings, the entire recognized text is displayed.)
+        }
+#pragma warning restore CS1998
+    }
+
+}

--- a/Extension/Azure/AzureStreamVoiceRequestProvider.cs.meta
+++ b/Extension/Azure/AzureStreamVoiceRequestProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0b4b0867f8614fbd88444ef68aa6fb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.ja.md
+++ b/README.ja.md
@@ -43,6 +43,7 @@ ChatdollKitは、お好みの3Dモデルを使って音声対話可能なチャ�
 - [uLipSync](https://github.com/hecomi/uLipSync)(v2.6.1)
 - For VRM model: [UniVRM](https://github.com/vrm-c/UniVRM/releases/tag/v0.89.0)(v0.89.0) and [VRM Extension](https://github.com/uezo/ChatdollKit/releases)
 - JSON.NET: プロジェクトにない場合は Package Manager > [+] > Add package from git URL... > com.unity.nuget.newtonsoft-json から追加
+- [Azure Speech SDK](https://learn.microsoft.com/ja-jp/azure/ai-services/speech-service/quickstarts/setup-platform?pivots=programming-language-csharp&tabs=macos%2Cubuntu%2Cdotnetcli%2Cunity%2Cjre%2Cmaven%2Cnodejs%2Cmac%2Cpypi#install-the-speech-sdk-for-unity): (Optional) ストリームによるリアルタイム音声認識を行う場合には必要
 
 <img src="Documents/Images/burst.png" width="640">
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Download the latest version of [ChatdollKit.unitypackage](https://github.com/uez
 - [uLipSync](https://github.com/hecomi/uLipSync)(v2.6.1)
 - For VRM model: [UniVRM](https://github.com/vrm-c/UniVRM/releases/tag/v0.89.0)(v0.89.0) and [VRM Extension](https://github.com/uezo/ChatdollKit/releases)
 - JSON.NET: If your project doesn't have JSON.NET, add it from Package Manager > [+] > Add package from git URL... > com.unity.nuget.newtonsoft-json
+- [Azure Speech SDK](https://learn.microsoft.com/ja-jp/azure/ai-services/speech-service/quickstarts/setup-platform?pivots=programming-language-csharp&tabs=macos%2Cubuntu%2Cdotnetcli%2Cunity%2Cjre%2Cmaven%2Cnodejs%2Cmac%2Cpypi#install-the-speech-sdk-for-unity): (Optional) Required for real-time speech recognition using a stream.
 
 <img src="Documents/Images/burst.png" width="640">
 

--- a/Scripts/Dialog/VoiceRequestProviderBase.cs
+++ b/Scripts/Dialog/VoiceRequestProviderBase.cs
@@ -29,7 +29,7 @@ namespace ChatdollKit.Dialog
         [Header("UI")]
         public MessageWindowBase MessageWindow;
         [SerializeField]
-        private string listeningMessage = "[ Listening ... ]";
+        protected string listeningMessage = "[ Listening ... ]";
         public Action OnListeningStart;
         public Action OnListeningStop;
         public Action OnRecordingStart = () => { Debug.Log("Recording voice request started"); };
@@ -46,12 +46,12 @@ namespace ChatdollKit.Dialog
             = async (r, t) => { Debug.LogWarning("VoiceRequestProvider.OnErrorAsync is not implemented"); };
 #pragma warning restore CS1998
 
-        // Private and protected members for recording voice and recognize task
-        private string recognitionId = string.Empty;
+        // Protected members for recording voice and recognize task
+        protected string recognitionId = string.Empty;
         protected ChatdollHttp client = new ChatdollHttp();
 
 #pragma warning disable CS1998
-        private async UniTask OnStartListeningDefaultAsync(Request request, CancellationToken token)
+        protected virtual async UniTask OnStartListeningDefaultAsync(Request request, CancellationToken token)
         {
             if (MessageWindow != null)
             {
@@ -63,7 +63,7 @@ namespace ChatdollKit.Dialog
             }
         }
 
-        private async UniTask OnFinishListeningDefaultAsync(Request request, CancellationToken token)
+        protected virtual async UniTask OnFinishListeningDefaultAsync(Request request, CancellationToken token)
         {
             if (MessageWindow != null)
             {
@@ -77,7 +77,7 @@ namespace ChatdollKit.Dialog
 #pragma warning restore CS1998
 
         // Create request using voice recognition
-        public async UniTask<Request> GetRequestAsync(CancellationToken token)
+        public virtual async UniTask<Request> GetRequestAsync(CancellationToken token)
         {
             var request = new Request(RequestType);
 


### PR DESCRIPTION
Use `AzureStreamVoiceRequestProvider` to perform real-time speech recognition.
This component depends on [Azure Speech SDK](https://learn.microsoft.com/ja-jp/azure/ai-services/speech-service/quickstarts/setup-platform?pivots=programming-language-csharp&tabs=macos%2Cubuntu%2Cdotnetcli%2Cunity%2Cjre%2Cmaven%2Cnodejs%2Cmac%2Cpypi#install-the-speech-sdk-for-unity).

NOTE: Microphone volume slider doesn't support controlling this component.