### PR TITLE
Support custom request parameters and headers for LLM APIs

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -21,6 +21,11 @@ namespace ChatdollKit.LLM.ChatGPT
         public bool IsAzure;
         public int MaxTokens = 0;
         public float Temperature = 0.5f;
+        public float FrequencyPenalty = 0.0f;
+        public bool Logprobs = false;  // Not available on gpt-4v
+        public int TopLogprobs = 0;    // Set true to Logprobs to use TopLogprobs
+        public float PresencePenalty = 0.0f;
+        public List<string> Stop;
 
         [Header("Network configuration")]
         [SerializeField]
@@ -151,8 +156,11 @@ namespace ChatdollKit.LLM.ChatGPT
                 { "model", Model },
                 { "temperature", Temperature },
                 { "messages", chatGPTSession.Contexts },
+                { "frequency_penalty", FrequencyPenalty },
+                { "presence_penalty", PresencePenalty },
                 { "stream", true },
             };
+
             if (MaxTokens > 0)
             {
                 data.Add("max_tokens", MaxTokens);
@@ -160,6 +168,15 @@ namespace ChatdollKit.LLM.ChatGPT
             if (useFunctions && llmTools.Count > 0 && !Model.ToLower().Contains("vision"))
             {
                 data.Add("functions", llmTools);
+            }
+            if (Logprobs == true)
+            {
+                data.Add("logprobs", true);
+                data.Add("top_logprobs", TopLogprobs);
+            }
+            if (Stop != null && Stop.Count > 0)
+            {
+                data.Add("stop", Stop);
             }
 
             // Prepare API request

--- a/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
@@ -42,6 +42,8 @@ namespace ChatdollKit.LLM.ChatGPT
                 { "model", Model },
                 { "temperature", Temperature },
                 { "messages", chatGPTSession.Contexts },
+                { "frequency_penalty", FrequencyPenalty },
+                { "presence_penalty", PresencePenalty },
                 { "stream", true },
             };
             if (MaxTokens > 0)
@@ -51,6 +53,15 @@ namespace ChatdollKit.LLM.ChatGPT
             if (useFunctions && llmTools.Count > 0)
             {
                 data.Add("functions", llmTools);
+            }
+            if (Logprobs == true)
+            {
+                data.Add("logprobs", true);
+                data.Add("top_logprobs", TopLogprobs);
+            }
+            if (Stop != null && Stop.Count > 0)
+            {
+                data.Add("stop", Stop);
             }
 
             // Start API stream

--- a/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
@@ -30,7 +30,7 @@ namespace ChatdollKit.LLM.ChatGPT
         protected bool isChatCompletionJSDone { get; set; } = false;
         protected Dictionary<string, ChatGPTSession> sessions { get; set; } = new Dictionary<string, ChatGPTSession>();
 
-        public override async UniTask StartStreamingAsync(ChatGPTSession chatGPTSession, bool useFunctions = true, CancellationToken token = default)
+        public override async UniTask StartStreamingAsync(ChatGPTSession chatGPTSession, Dictionary<string, string> customParameters, Dictionary<string, string> customHeaders, bool useFunctions = true, CancellationToken token = default)
         {
             // Add session for callback
             var sessionId = Guid.NewGuid().ToString();
@@ -62,6 +62,16 @@ namespace ChatdollKit.LLM.ChatGPT
             if (Stop != null && Stop.Count > 0)
             {
                 data.Add("stop", Stop);
+            }
+            foreach (var p in customParameters)
+            {
+                data[p.Key] = p.Value;
+            }
+
+            // TODO: Support custom headers later...
+            if (customHeaders.Count >= 0)
+            {
+                Debug.LogWarning("Custom headers for ChatGPT on WebGL is not supported for now.");
             }
 
             // Start API stream

--- a/Scripts/LLM/Claude/ClaudeServiceWebGL.cs
+++ b/Scripts/LLM/Claude/ClaudeServiceWebGL.cs
@@ -30,7 +30,7 @@ namespace ChatdollKit.LLM.Claude
         protected bool isChatCompletionJSDone { get; set; } = false;
         protected Dictionary<string, ClaudeSession> sessions { get; set; } = new Dictionary<string, ClaudeSession>();
 
-        public override async UniTask StartStreamingAsync(ClaudeSession claudeSession, bool useFunctions = true, CancellationToken token = default)
+        public override async UniTask StartStreamingAsync(ClaudeSession claudeSession, Dictionary<string, string> customParameters, Dictionary<string, string> customHeaders, bool useFunctions = true, CancellationToken token = default)
         {
             // Add session for callback
             var sessionId = Guid.NewGuid().ToString();
@@ -50,6 +50,16 @@ namespace ChatdollKit.LLM.Claude
             if (TopK > 0)
             {
                 data.Add("top_k", TopK);
+            }
+            foreach (var p in customParameters)
+            {
+                data[p.Key] = p.Value;
+            }
+
+            // TODO: Support custom headers later...
+            if (customHeaders.Count >= 0)
+            {
+                Debug.LogWarning("Custom headers for Claude on WebGL is not supported for now.");
             }
 
             // Start API stream

--- a/Scripts/LLM/Gemini/GeminiServiceWebGL.cs
+++ b/Scripts/LLM/Gemini/GeminiServiceWebGL.cs
@@ -30,7 +30,7 @@ namespace ChatdollKit.LLM.Gemini
         protected bool isChatCompletionJSDone { get; set; } = false;
         protected Dictionary<string, GeminiSession> sessions { get; set; } = new Dictionary<string, GeminiSession>();
 
-        public override async UniTask StartStreamingAsync(GeminiSession geminiSession, bool useFunctions = true, CancellationToken token = default)
+        public override async UniTask StartStreamingAsync(GeminiSession geminiSession, Dictionary<string, string> customParameters, Dictionary<string, string> customHeaders, bool useFunctions = true, CancellationToken token = default)
         {
             // Add session for callback
             var sessionId = Guid.NewGuid().ToString();
@@ -52,6 +52,16 @@ namespace ChatdollKit.LLM.Gemini
                 { "contents", geminiSession.Contexts },
                 { "generationConfig", generationConfig }
             };
+            foreach (var p in customParameters)
+            {
+                data[p.Key] = p.Value;
+            }
+
+            // TODO: Support custom headers later...
+            if (customHeaders.Count >= 0)
+            {
+                Debug.LogWarning("Custom headers for Gemini on WebGL is not supported for now.");
+            }
 
             // Set tools. Multimodal model doesn't support function calling for now (2023.12.29)
             if (useFunctions && llmTools.Count > 0 && !Model.ToLower().Contains("vision"))


### PR DESCRIPTION
Set additional parameters and HTTP headers as Dictionary<string, string> to state.Data with `CustomParameterKey` and `CustomHeaderKey`.
This feature helps work well with some private reverse proxies.