### PR TITLE
Set message windows automatically without configurations

### DIFF
--- a/Scripts/Dialog/DialogController.cs
+++ b/Scripts/Dialog/DialogController.cs
@@ -109,12 +109,35 @@ namespace ChatdollKit.Dialog
             var stateStore = GetComponent<IStateStore>();
             var skillRouter = GetComponent<ISkillRouter>();
 
+            // Search message windows
+            foreach (var messageWindow in GetComponentsInChildren<MessageWindowBase>(true))
+            {
+                if (messageWindow.name == "UserMessageWindow" && UserMessageWindow == null)
+                {
+                    UserMessageWindow = messageWindow;
+                }
+                else if (messageWindow.name == "CharacterMessageWindow" && CharacterMessageWindow == null)
+                {
+                    CharacterMessageWindow = messageWindow;
+                }
+            }
+
+            // User message window
+            if (UserMessageWindow == null)
+            {
+                Debug.LogWarning("UserMessageWindow is not set.");
+            }
             if (!UserMessageWindow.IsInstance)
             {
                 // Create MessageWindow instance
                 UserMessageWindow = Instantiate(UserMessageWindow);
             }
 
+            // Character message window
+            if (CharacterMessageWindow == null)
+            {
+                Debug.LogWarning("CharacterMessageWindow is not set.");
+            }
             // Synchronize speech and character message window
             modelController.OnSayStart = (text, token) =>
             {


### PR DESCRIPTION
Now UserMessageWindow and CharacterMessageWindow should be set manually to DialogController. If not `Awake` fails and conversation can't be processed forever. This change prevents such error by searching and setting message windows automatically if not set.