### PR TITLE
Fix incorrect volume measurement bug

### DIFF
--- a/Scripts/IO/ChatdollMicrophone.cs
+++ b/Scripts/IO/ChatdollMicrophone.cs
@@ -117,6 +117,13 @@ namespace ChatdollKit.IO
                 Debug.Log("Permission for microphone is granted");
             }
 
+            if (!Microphone.IsRecording(listeningDeviceName))
+            {
+                Debug.LogWarning("Microphone stopped unexpectedly. Restarting microphone...");
+                StartListening();
+                return;
+            }
+
             try
             {
                 // Get position
@@ -278,7 +285,7 @@ namespace ChatdollKit.IO
         {
             ChannelCount = channelCount;
             Frequency = frequency;
-            Volume = 0;
+            Volume = -99.9f;
             Data = new float[] { };
         }
 


### PR DESCRIPTION
Corrected the issue where the absence of input from the microphone was recognized as the maximum volume. Now, it is recognized as the minimum volume.

Additionally, implemented a feature to restart input from the microphone if the device unexpectedly terminates, improving the stability of the speech recognition.