### PR TITLE
Add vision input support for WebGL

### DIFF
--- a/Demo/Scripts/Main.cs
+++ b/Demo/Scripts/Main.cs
@@ -111,7 +111,7 @@ namespace ChatdollKit.Demo
             }
 
             // Setting on start
-            settingsUI.Show();
+            settingsUI.Show(initializeComponents: true);
 
             // Animation and face expression for start up
             var animationOnStart = new List<Model.Animation>();
@@ -143,8 +143,6 @@ namespace ChatdollKit.Demo
 
         private async UniTask<byte[]> CaptureImageAsync(string source)
         {
-            Debug.LogWarning("cap");
-
             if (simpleCamera != null)
             {
                 try

--- a/Demo/Scripts/SettingsUI.cs
+++ b/Demo/Scripts/SettingsUI.cs
@@ -53,6 +53,11 @@ namespace ChatdollKit.Demo
 
         private void Start()
         {
+            InitializeComponents();
+        }
+
+        private void InitializeComponents()
+        {
             if (chatdollKitObject == null)
             {
                 chatdollKitObject = FindObjectOfType<ChatdollKit>()?.gameObject;
@@ -70,20 +75,11 @@ namespace ChatdollKit.Demo
             voicevoxTTSLoader = chatdollKitObject.GetComponent<VoicevoxTTS>();
         }
 
-        public void Show()
+        public void Show(bool initializeComponents = false)
         {
-            if (chatdollKitObject == null)
+            if (initializeComponents)
             {
-                chatdollKitObject = FindObjectOfType<ChatdollKit>()?.gameObject;
-                if (chatdollKitObject == null)
-                {
-                    Debug.LogError("ChatdollKit is not found in this scene.");
-                }
-            }
-
-            if (dialogController == null)
-            {
-                dialogController = chatdollKitObject.GetComponent<DialogController>();
+                InitializeComponents();
             }
 
             // Get LLMService components
@@ -123,7 +119,6 @@ namespace ChatdollKit.Demo
 
             OnChangeLLMDropdown();
 
-            // TTS
             if (!string.IsNullOrEmpty(voicevoxTTSLoader.EndpointUrl))
             {
                 TTSUrlInput.text = voicevoxTTSLoader.EndpointUrl;

--- a/Scripts/IO/ChatdollMicrophone.cs
+++ b/Scripts/IO/ChatdollMicrophone.cs
@@ -117,12 +117,14 @@ namespace ChatdollKit.IO
                 Debug.Log("Permission for microphone is granted");
             }
 
+#if !UNITY_WEBGL || UNITY_EDITOR
             if (!Microphone.IsRecording(listeningDeviceName))
             {
                 Debug.LogWarning("Microphone stopped unexpectedly. Restarting microphone...");
                 StartListening();
                 return;
             }
+#endif
 
             try
             {


### PR DESCRIPTION
- Implement Vision input support for WebGL.
- Note: In Unity 2022, a bug causes pixel data retrieved from WebCamTexture to appear black. This bug is resolved in Unity 2022.3.26f1 and later, so ensure to use this or a newer version.

https://issuetracker.unity3d.com/issues/webcamtexture-dot-getpixels32-returns-black-pixels-when-in-webgl-player