### PR TITLE
Add support for Dify💙

### DIFF
--- a/Plugins/DifyServiceWebGL.jslib
+++ b/Plugins/DifyServiceWebGL.jslib
@@ -1,0 +1,45 @@
+mergeInto(LibraryManager.library, {
+    StartDifyMessageStreamJS: function(targetObjectNamePtr, sessionIdPtr, urlPtr, apiKeyPtr, userPtr, difyStreamRequestPtr) {
+        let targetObjectName = UTF8ToString(targetObjectNamePtr);
+        let sessionId = UTF8ToString(sessionIdPtr);
+        let url = UTF8ToString(urlPtr);
+        let apiKey = UTF8ToString(apiKeyPtr);
+        let user = UTF8ToString(userPtr);
+        let difyStreamRequest = UTF8ToString(difyStreamRequestPtr);
+        let decoder = new TextDecoder("utf-8");
+
+        if (document.difyAbortController == null) {
+            document.difyAbortController = new AbortController();
+        }
+
+        fetch(url, {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${apiKey}`
+            },
+            method: "POST",
+            body: difyStreamRequest,
+            signal: document.difyAbortController.signal
+        })
+        .then((response) => response.body.getReader())
+        .then((reader) => {
+            const readChunk = function({done, value}) {
+                if(done) {
+                    reader.releaseLock();
+                    return;
+                }
+                SendMessage(targetObjectName, "SetDifyMessageStreamChunk", sessionId + "::" + decoder.decode(value));
+                reader.read().then(readChunk);
+            }
+            reader.read().then(readChunk);
+        })
+        .catch((err) => {
+            console.error(`Error at fetch: ${err.message}`);
+        });
+    },
+
+    AbortDifyMessageStreamJS: function() {
+        console.log("Abort Dify at AbortDifyMessageStreamJS");
+        document.difyAbortController.abort();
+    }
+});

--- a/Plugins/DifyServiceWebGL.jslib.meta
+++ b/Plugins/DifyServiceWebGL.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: a6cd9cd5adbee44db80bb75500f923ff
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/LLM/Dify.meta
+++ b/Scripts/LLM/Dify.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48e74eb38d83d40c891813e12a099a47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/LLM/Dify/DifyService.cs
+++ b/Scripts/LLM/Dify/DifyService.cs
@@ -1,0 +1,347 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Networking;
+using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ChatdollKit.LLM.Dify
+{
+    public class DifyService : LLMServiceBase
+    {
+        public string CustomParameterKey = "DifyParameters";
+        public string CustomHeaderKey = "DifyHeaders";
+
+        [Header("API configuration")]
+        public string ApiKey;
+        public string BaseUrl;
+        public string User;
+
+        [Header("Network configuration")]
+        [SerializeField]
+        protected int responseTimeoutSec = 30;
+        [SerializeField]
+        protected float noDataResponseTimeoutSec = 10.0f;
+
+        protected string CurrentConversationId = string.Empty;
+
+        public Func<string, UniTask<byte[]>> CaptureImage = null;
+
+#pragma warning disable CS1998
+        public override async UniTask<List<ILLMMessage>> MakePromptAsync(string userId, string inputText, Dictionary<string, object> payloads, CancellationToken token = default)
+        {
+            var messages = new List<ILLMMessage>();
+
+            if (((Dictionary<string, object>)payloads["RequestPayloads"]).ContainsKey("imageBytes"))
+            {
+                // Message with image
+                var imageBytes = (byte[])((Dictionary<string, object>)payloads["RequestPayloads"])["imageBytes"];
+                var uploadedImageId = await UploadImage(imageBytes);
+                messages.Add(new DifyRequestMessage(inputText, uploadedImageId));
+            }
+            else
+            {
+                // Text message
+                messages.Add(new DifyRequestMessage(inputText));
+            }
+
+            return messages;
+        }
+#pragma warning restore CS1998
+
+        public override async UniTask<ILLMSession> GenerateContentAsync(List<ILLMMessage> messages, Dictionary<string, object> payloads, bool useFunctions = true, int retryCounter = 1, CancellationToken token = default)
+        {
+            // Custom parameters and headers
+            var stateData = (Dictionary<string, object>)payloads["StateData"];
+            var customParameters = stateData.ContainsKey(CustomParameterKey) ? (Dictionary<string, string>)stateData[CustomParameterKey] : new Dictionary<string, string>();
+            var customHeaders = stateData.ContainsKey(CustomHeaderKey) ? (Dictionary<string, string>)stateData[CustomHeaderKey] : new Dictionary<string, string>();
+
+            // Start streaming session
+            var difySession = new DifySession();
+            difySession.Contexts = messages;
+            difySession.StreamingTask = StartStreamingAsync(difySession, stateData, customParameters, customHeaders, useFunctions, token);
+
+            // Retry
+            if (difySession.ResponseType == ResponseType.Timeout)
+            {
+                if (retryCounter > 0)
+                {
+                    Debug.LogWarning($"Dify timeouts with no response data. Retrying ...");
+                    difySession = (DifySession)await GenerateContentAsync(messages, payloads, useFunctions, retryCounter - 1, token);
+                }
+                else
+                {
+                    Debug.LogError($"Dify timeouts with no response data.");
+                    difySession.ResponseType = ResponseType.Error;
+                    difySession.StreamBuffer = ErrorMessageContent;
+                }
+            }
+
+            return difySession;
+        }
+
+        public virtual async UniTask StartStreamingAsync(DifySession difySession, Dictionary<string, object> stateData, Dictionary<string, string> customParameters, Dictionary<string, string> customHeaders, bool useFunctions = true, CancellationToken token = default)
+        {
+            difySession.CurrentStreamBuffer = string.Empty;
+
+            var difyRequest = (DifyRequestMessage)difySession.Contexts[0];
+
+            // Make request data
+            var data = new Dictionary<string, object>()
+            {
+                { "inputs", new Dictionary<string, string>() },
+                { "query", difyRequest.query },
+                { "response_mode", "streaming" },
+                { "user", User },
+                { "auto_generate_name", false },
+            };
+
+            if (!string.IsNullOrEmpty(difyRequest.uploaded_file_id))
+            {
+                data["files"] = new List<Dictionary<string, string>>()
+                {
+                    new Dictionary<string, string>()
+                    {
+                        { "type", "image" },
+                        { "transfer_method", "local_file" },
+                        { "upload_file_id", difyRequest.uploaded_file_id }
+                    }
+                };
+            }
+
+            if (!string.IsNullOrEmpty(CurrentConversationId))
+            {
+                data.Add("conversation_id", CurrentConversationId);
+            }
+
+            foreach (var p in customParameters)
+            {
+                data[p.Key] = p.Value;
+            }
+
+            // Prepare API request
+            using var streamRequest = new UnityWebRequest(
+                BaseUrl + "/chat-messages",
+                "POST"
+            );
+            streamRequest.timeout = responseTimeoutSec;
+            streamRequest.SetRequestHeader("Content-Type", "application/json");
+            streamRequest.SetRequestHeader("Authorization", "Bearer " + ApiKey);
+            foreach (var h in customHeaders)
+            {
+                streamRequest.SetRequestHeader(h.Key, h.Value);
+            }
+
+            if (DebugMode)
+            {
+                Debug.Log($"Request to Dify: {JsonConvert.SerializeObject(data)}");
+            }
+            var bodyRaw = System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
+
+            // Request and response handlers
+            streamRequest.uploadHandler = new UploadHandlerRaw(bodyRaw);
+            var downloadHandler = new DifyStreamDownloadHandler();
+            downloadHandler.DebugMode = DebugMode;
+            downloadHandler.SetReceivedChunk = (answer, convid) =>
+            {
+                difySession.CurrentStreamBuffer += answer;
+                difySession.StreamBuffer += answer;
+                if (!string.IsNullOrEmpty(convid))
+                {
+                    CurrentConversationId = convid;
+                }
+            };
+            streamRequest.downloadHandler = downloadHandler;
+
+            // Start API stream
+            _ = streamRequest.SendWebRequest();
+
+            // Preprocessing response
+            var noDataResponseTimeoutsAt = DateTime.Now.AddMilliseconds(noDataResponseTimeoutSec * 1000);
+            while (true)
+            {
+                // Success
+                if (streamRequest.result == UnityWebRequest.Result.Success)
+                {
+                    break;
+                }
+
+                // Timeout with no response data
+                else if (streamRequest.downloadedBytes == 0 && DateTime.Now > noDataResponseTimeoutsAt)
+                {
+                    streamRequest.Abort();
+                    difySession.ResponseType = ResponseType.Timeout;
+                    break;
+                }
+
+                // Other errors
+                else if (streamRequest.isDone)
+                {
+                    Debug.LogError($"Dify ends with error ({streamRequest.result}): {streamRequest.error}");
+                    difySession.ResponseType = ResponseType.Error;
+                    break;
+                }
+
+                // Cancel
+                else if (token.IsCancellationRequested)
+                {
+                    Debug.Log("Preprocessing response from Dify canceled.");
+                    difySession.ResponseType = ResponseType.Error;
+                    streamRequest.Abort();
+                    break;
+                }
+
+                await UniTask.Delay(10);
+            }
+
+            var extractedTags = ExtractTags(difySession.CurrentStreamBuffer);
+
+            if (CaptureImage != null && extractedTags.ContainsKey("vision") && difySession.IsVisionAvailable)
+            {
+                // Prevent infinit loop
+                difySession.IsVisionAvailable = false;
+
+                // Get image
+                var imageBytes = await CaptureImage(extractedTags["vision"]);
+
+                // Make contexts
+                if (imageBytes != null)
+                {
+                    // Upload image
+                    var uploadedImageId = await UploadImage(imageBytes);
+                    if (string.IsNullOrEmpty(uploadedImageId))
+                    {
+                        difySession.Contexts = new List<ILLMMessage>() { new DifyRequestMessage("Please inform the user that an error occurred while capturing the image.") };
+                    }
+                    else
+                    {
+                        difyRequest.uploaded_file_id = uploadedImageId;
+                    }
+                }
+                else
+                {
+                    difySession.Contexts = new List<ILLMMessage>() { new DifyRequestMessage("Please inform the user that an error occurred while capturing the image.") };
+                }
+
+                // Call recursively with image
+                await StartStreamingAsync(difySession, stateData, customParameters, customHeaders, useFunctions, token);
+            }
+            else
+            {
+                difySession.IsResponseDone = true;
+
+                if (DebugMode)
+                {
+                    Debug.Log($"Response from Dify: {JsonConvert.SerializeObject(difySession.StreamBuffer)}");
+                }
+            }
+        }
+
+        protected virtual async UniTask<string> UploadImage(byte[] imageBytes)
+        {
+            try
+            {
+                var form = new WWWForm();
+                form.AddField("user", User);
+                form.AddBinaryData("file", imageBytes, "image.png", "image/png");
+
+                var request = UnityWebRequest.Post(BaseUrl + "/files/upload", form);
+                request.SetRequestHeader("Authorization", "Bearer " + ApiKey);
+
+                await request.SendWebRequest();
+
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    Debug.LogError($"Error at UploadImage: {request.error}");
+                    return null;
+                }
+                else
+                {
+                    var responseText = request.downloadHandler.text;
+                    var responseJson = JsonConvert.DeserializeObject<DifyImageUploadResponse>(responseText);
+                    string id = responseJson.id;
+                    return id;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Error at UploadImage: {ex.Message}\n{ex.StackTrace}");
+            }
+
+            return null;
+        }
+
+        protected class DifyStreamDownloadHandler : DownloadHandlerScript
+        {
+            public Action<string, string> SetReceivedChunk;
+            public bool DebugMode = false;
+
+            protected override bool ReceiveData(byte[] data, int dataLength)
+            {
+                if (data == null || data.Length < 1) return false;
+
+                var receivedData = System.Text.Encoding.UTF8.GetString(data, 0, dataLength);
+                if (DebugMode)
+                {
+                    Debug.Log($"Chunk from Dify: {receivedData}");
+                }
+
+                var resp = string.Empty;
+                foreach (string line in receivedData.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (line.StartsWith("data:"))
+                    {
+                        var d = line.Substring("data:".Length).Trim();
+
+                        try
+                        {
+                            var dsr = JsonConvert.DeserializeObject<DifyStreamResponse>(d);
+                            if (dsr.@event == "message")
+                            {
+                                SetReceivedChunk(dsr.answer, dsr.conversation_id);
+                                continue;
+                            }
+                        }
+                        catch (Exception)
+                        {
+                            Debug.LogError($"Deserialize error: {d}");
+                            continue;
+                        }
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+
+    public class DifySession : LLMSession
+    {
+
+    }
+
+    public class DifyRequestMessage : ILLMMessage
+    {
+        public string query { get; set; }
+        public string uploaded_file_id { get; set; }
+
+        public DifyRequestMessage(string query, string uploaded_file_id = null)
+        {
+            this.query = query;
+            this.uploaded_file_id = uploaded_file_id;
+        }
+    }
+
+    public class DifyStreamResponse
+    {
+        public string @event { get; set; }
+        public string conversation_id { get; set; }
+        public string answer { get; set; }
+    }
+
+    public class DifyImageUploadResponse
+    {
+        public string id;
+    }
+}

--- a/Scripts/LLM/Dify/DifyService.cs.meta
+++ b/Scripts/LLM/Dify/DifyService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 598a633cd394540c5a72f940b078e297
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/LLM/Dify/DifyServiceWebGL.cs
+++ b/Scripts/LLM/Dify/DifyServiceWebGL.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using UnityEngine;
+using Newtonsoft.Json;
+using Cysharp.Threading.Tasks;
+
+namespace ChatdollKit.LLM.Dify
+{
+    public class DifyServiceWebGL : DifyService
+    {
+        public override bool IsEnabled
+        {
+            get
+            {
+#if UNITY_WEBGL && !UNITY_EDITOR
+                return _IsEnabled;
+#else
+                return false;
+#endif
+            }
+        }
+
+#if UNITY_WEBGL
+        [DllImport("__Internal")]
+        protected static extern void StartDifyMessageStreamJS(string targetObjectName, string sessionId, string url, string apiKey, string user, string chatCompletionRequest);
+        [DllImport("__Internal")]
+        protected static extern void AbortDifyMessageStreamJS();
+
+        protected bool isChatCompletionJSDone { get; set; } = false;
+        protected Dictionary<string, DifySession> sessions { get; set; } = new Dictionary<string, DifySession>();
+
+        public override async UniTask StartStreamingAsync(DifySession difySession, Dictionary<string, object> stateData, Dictionary<string, string> customParameters, Dictionary<string, string> customHeaders, bool useFunctions = true, CancellationToken token = default)
+        {
+            difySession.CurrentStreamBuffer = string.Empty;
+
+            var difyRequest = (DifyRequestMessage)difySession.Contexts[0];
+
+            string sessionId;
+            if (stateData.ContainsKey("difySessionId"))
+            {
+                // Use existing session id for callback
+                sessionId = (string)stateData["difySessionId"];
+            }
+            else
+            {
+                // Add session for callback
+                sessionId = Guid.NewGuid().ToString();
+                sessions.Add(sessionId, difySession);
+            }
+
+            // Make request data
+            var data = new Dictionary<string, object>()
+            {
+                { "inputs", new Dictionary<string, string>() },
+                { "query", difyRequest.query },
+                { "response_mode", "streaming" },
+                { "user", User },
+                { "auto_generate_name", false },
+            };
+
+            if (!string.IsNullOrEmpty(difyRequest.uploaded_file_id))
+            {
+                data["files"] = new List<Dictionary<string, string>>()
+                {
+                    new Dictionary<string, string>()
+                    {
+                        { "type", "image" },
+                        { "transfer_method", "local_file" },
+                        { "upload_file_id", difyRequest.uploaded_file_id }
+                    }
+                };
+            }
+
+            if (!string.IsNullOrEmpty(CurrentConversationId))
+            {
+                data.Add("conversation_id", CurrentConversationId);
+            }
+
+            foreach (var p in customParameters)
+            {
+                data[p.Key] = p.Value;
+            }
+
+            // TODO: Support custom headers later...
+            if (customHeaders.Count >= 0)
+            {
+                Debug.LogWarning("Custom headers for Dify on WebGL is not supported for now.");
+            }
+
+            var serializedData = JsonConvert.SerializeObject(data);
+
+            if (DebugMode)
+            {
+                Debug.Log($"Request to Dify: {serializedData}");
+            }
+
+            // Start API stream
+            isChatCompletionJSDone = false;
+            StartDifyMessageStreamJS(
+                gameObject.name,
+                sessionId,
+                BaseUrl + "/chat-messages",
+                ApiKey,
+                User,
+                serializedData
+            );
+
+            // Preprocessing response
+            var noDataResponseTimeoutsAt = DateTime.Now.AddMilliseconds(noDataResponseTimeoutSec * 1000);
+            while (true)
+            {
+                // Success
+                if (!string.IsNullOrEmpty(difySession.StreamBuffer) && isChatCompletionJSDone)
+                {
+                    break;
+                }
+
+                // Timeout with no response data
+                else if (string.IsNullOrEmpty(difySession.StreamBuffer) && DateTime.Now > noDataResponseTimeoutsAt)
+                {
+                    Debug.LogError($"Dify timeouts");
+                    AbortDifyMessageStreamJS();
+                    difySession.ResponseType = ResponseType.Timeout;
+                    sessions.Remove(sessionId);
+                    break;
+                }
+
+                // Other errors
+                else if (isChatCompletionJSDone)
+                {
+                    Debug.LogError($"Dify ends with error");
+                    difySession.ResponseType = ResponseType.Error;
+                    break;
+                }
+
+                // Cancel
+                else if (token.IsCancellationRequested)
+                {
+                    Debug.Log("Preprocessing response from Dify canceled.");
+                    difySession.ResponseType = ResponseType.Error;
+                    AbortDifyMessageStreamJS();
+                    break;
+                }
+
+                await UniTask.Delay(10);
+            }
+
+            var extractedTags = ExtractTags(difySession.CurrentStreamBuffer);
+
+            if (CaptureImage != null && extractedTags.ContainsKey("vision") && difySession.IsVisionAvailable)
+            {
+                // Prevent infinit loop
+                difySession.IsVisionAvailable = false;
+
+                // Get image
+                var imageBytes = await CaptureImage(extractedTags["vision"]);
+
+                // Make contexts
+                if (imageBytes != null)
+                {
+                    // Upload image
+                    var uploadedImageId = await UploadImage(imageBytes);
+                    if (string.IsNullOrEmpty(uploadedImageId))
+                    {
+                        difySession.Contexts = new List<ILLMMessage>() { new DifyRequestMessage("Please inform the user that an error occurred while capturing the image.") };
+                    }
+                    else
+                    {
+                        difyRequest.uploaded_file_id = uploadedImageId;
+                    }
+                }
+                else
+                {
+                    difySession.Contexts = new List<ILLMMessage>() { new DifyRequestMessage("Please inform the user that an error occurred while capturing the image.") };
+                }
+
+                // Call recursively with image
+                await StartStreamingAsync(difySession, stateData, customParameters, customHeaders, useFunctions, token);
+            }
+            else
+            {
+                difySession.IsResponseDone = true;
+
+                sessions.Remove(sessionId);
+
+                if (DebugMode)
+                {
+                    Debug.Log($"Response from Dify: {JsonConvert.SerializeObject(difySession.StreamBuffer)}");
+                }
+            }
+        }
+
+        public void SetDifyMessageStreamChunk(string chunkStringWithSessionId)
+        {
+            var splittedChunk = chunkStringWithSessionId.Split("::");
+            var sessionId = splittedChunk[0];
+            var chunkString = splittedChunk[1];
+
+            if (string.IsNullOrEmpty(chunkString))
+            {
+                Debug.Log("Chunk is null or empty. Set true to isChatCompletionJSDone.");
+                isChatCompletionJSDone = true;
+                return;
+            }
+
+            if (DebugMode)
+            {
+                Debug.Log($"Chunk from Dify: {chunkString}");
+            }
+
+            if (!sessions.ContainsKey(sessionId))
+            {
+                Debug.LogWarning($"Session not found. Set true to isChatCompletionJSDone.: {sessionId}");
+                isChatCompletionJSDone = true;
+                return;
+            }
+
+            var difySession = sessions[sessionId];
+
+            var isDone = false;
+            foreach (string line in chunkString.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (line.StartsWith("data:"))
+                {
+                    var d = line.Substring("data:".Length).Trim();
+
+                    try
+                    {
+                        var dsr = JsonConvert.DeserializeObject<DifyStreamResponse>(d);
+                        if (dsr.@event == "message")
+                        {
+                            difySession.CurrentStreamBuffer += dsr.answer;
+                            difySession.StreamBuffer += dsr.answer;
+                            CurrentConversationId = dsr.conversation_id;
+                            continue;
+                        }
+                        else if (dsr.@event == "message_end")
+                        {
+                            isDone = true;
+                            break;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        Debug.LogError($"Deserialize error: {d}");
+                        continue;
+                    }
+                }
+            }
+
+            if (isDone)
+            {
+                isChatCompletionJSDone = true;
+            }
+        }
+#endif
+    }
+}

--- a/Scripts/LLM/Dify/DifyServiceWebGL.cs.meta
+++ b/Scripts/LLM/Dify/DifyServiceWebGL.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8e07bcff8a234af4b4ab5f41c7588dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
You can use the Dify API instead of a specific LLM's API. This eliminates the need to manage code for tools or RAG locally.

To use this feature, just attach `DifyService` instead of specific LLM service like `ChatGPTService` and set Is Default = true.