### PR TITLE
Add support for Dify Agents

### DIFF
--- a/Scripts/LLM/Dify/DifyService.cs
+++ b/Scripts/LLM/Dify/DifyService.cs
@@ -297,7 +297,7 @@ namespace ChatdollKit.LLM.Dify
                         try
                         {
                             var dsr = JsonConvert.DeserializeObject<DifyStreamResponse>(d);
-                            if (dsr.@event == "message")
+                            if (dsr.@event == "message" || dsr.@event == "agent_message")
                             {
                                 SetReceivedChunk(dsr.answer, dsr.conversation_id);
                                 continue;

--- a/Scripts/LLM/Dify/DifyServiceWebGL.cs
+++ b/Scripts/LLM/Dify/DifyServiceWebGL.cs
@@ -229,7 +229,7 @@ namespace ChatdollKit.LLM.Dify
                     try
                     {
                         var dsr = JsonConvert.DeserializeObject<DifyStreamResponse>(d);
-                        if (dsr.@event == "message")
+                        if (dsr.@event == "message" || dsr.@event == "agent_message")
                         {
                             difySession.CurrentStreamBuffer += dsr.answer;
                             difySession.StreamBuffer += dsr.answer;


### PR DESCRIPTION
Agents return `agent_message` event instead of `message` event.

See #312 