### PR TITLE
Add support for custom logic at the end of LLM streaming

### DIFF
--- a/Scripts/LLM/ILLMService.cs
+++ b/Scripts/LLM/ILLMService.cs
@@ -13,6 +13,7 @@ namespace ChatdollKit.LLM
         UniTask<List<ILLMMessage>> MakePromptAsync(string userId, string inputText, Dictionary<string, object> payloads, CancellationToken token = default);
         UniTask<ILLMSession> GenerateContentAsync(List<ILLMMessage> messages, Dictionary<string, object> payloads = null, bool useFunctions = true, int retryCounter = 1, CancellationToken token = default);
         ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null);
+        Func<ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
     }
 
     public enum ResponseType
@@ -28,6 +29,7 @@ namespace ChatdollKit.LLM
         bool IsVisionAvailable { get; set; }
         ResponseType ResponseType { get; set; }
         UniTask StreamingTask { get; set; }
+        Func<UniTask> OnStreamingEnd { get; set; }
         string FunctionName { get; set; }
         List<ILLMMessage> Contexts { get; set; }
     }

--- a/Scripts/LLM/LLMContentSkill.cs
+++ b/Scripts/LLM/LLMContentSkill.cs
@@ -60,6 +60,7 @@ namespace ChatdollKit.LLM
 
             // Wait API stream ends
             await llmSession.StreamingTask;
+            await llmSession.OnStreamingEnd();
 
             // Wait parsing and performance
             await parseTask;

--- a/Scripts/LLM/LLMRouter.cs
+++ b/Scripts/LLM/LLMRouter.cs
@@ -116,6 +116,13 @@ namespace ChatdollKit.LLM
             var messages = await llmService.MakePromptAsync(state.UserId, request.Text, payloads, token);
 
             var llmSession = await llmService.GenerateContentAsync(messages, payloads, token: token);
+            llmSession.OnStreamingEnd = async () =>
+            {
+                if (llmService.OnStreamingEnd != null)
+                {
+                    await llmService.OnStreamingEnd(llmSession, token);
+                }
+            };
             request.Payloads.Add("LLMSession", llmSession);
 
             if (!string.IsNullOrEmpty(llmSession.FunctionName))

--- a/Scripts/LLM/LLMServiceBase.cs
+++ b/Scripts/LLM/LLMServiceBase.cs
@@ -38,6 +38,8 @@ namespace ChatdollKit.LLM
 
         public Action OnEnabled { get; set; }
 
+        public Func<ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
+
         protected List<ILLMTool> llmTools = new List<ILLMTool>();
 
         public virtual void AddTool(ILLMTool tool)
@@ -90,6 +92,7 @@ namespace ChatdollKit.LLM
         public bool IsVisionAvailable { get; set; } = true;
         public ResponseType ResponseType { get; set; } = ResponseType.None;
         public UniTask StreamingTask { get; set; }
+        public Func<UniTask> OnStreamingEnd { get; set; }
         public string FunctionName { get; set; }
         public List<ILLMMessage> Contexts { get; set; }
 


### PR DESCRIPTION
Implement `LLMService.OnStreamingEnd()` if you want to do something at the end of streaming task. (e.g. add request and response to the backlog window) This method takes LLMSession and Cancellation as arguments.