### PR TITLE
Add option to completely disable WakeWordListener

### DIFF
--- a/Scripts/Dialog/DialogController.cs
+++ b/Scripts/Dialog/DialogController.cs
@@ -14,6 +14,7 @@ namespace ChatdollKit.Dialog
         [Header("Wake Word and Cancel Word")]
         [SerializeField] protected string WakeWord;
         [SerializeField] protected string CancelWord;
+        [SerializeField] protected bool controlWakeWordListenerInDialog = true;
 
         [Header("Prompt")]
         [SerializeField] protected string PromptVoice;
@@ -414,7 +415,10 @@ namespace ChatdollKit.Dialog
             var token = GetDialogToken();
 
             // Stop WakeWordListener and microphone
-            WakeWordListener.StopListening();
+            if (controlWakeWordListenerInDialog)
+            {
+                WakeWordListener.StopListening();
+            }
 
             // Request
             Request request = null;
@@ -604,13 +608,16 @@ namespace ChatdollKit.Dialog
             }
 
             // Control WakeWordListener
-            if ((Status != DialogStatus.Idling || IsMuted) && WakeWordListener.IsListening)
+            if (controlWakeWordListenerInDialog)
             {
-                WakeWordListener.StopListening();
-            }
-            else if (Status == DialogStatus.Idling && !IsMuted && !WakeWordListener.IsListening)
-            {
-                WakeWordListener.StartListening();
+                if ((Status != DialogStatus.Idling || IsMuted) && WakeWordListener.IsListening)
+                {
+                    WakeWordListener.StopListening();
+                }
+                else if (Status == DialogStatus.Idling && !IsMuted && !WakeWordListener.IsListening)
+                {
+                    WakeWordListener.StartListening();
+                }
             }
         }
     }

--- a/Scripts/Dialog/WakeWordListener/WakeWordListenerBase.cs
+++ b/Scripts/Dialog/WakeWordListener/WakeWordListenerBase.cs
@@ -10,7 +10,6 @@ namespace ChatdollKit.Dialog
 {
     public class WakeWordListenerBase : VoiceRecorderBase, IWakeWordListener
     {
-        public float VoiceDetectionRaisedThreshold = -15.0f;
         public float VoiceRecognitionMaximumLength = 3.0f;
 
         public bool AutoStart = true;
@@ -43,9 +42,13 @@ namespace ChatdollKit.Dialog
 
         protected virtual void Start()
         {
-            if (VoiceDetectionThreshold >= 0)
+            if (VoiceDetectionThreshold > 0)
             {
                 VoiceDetectionThreshold = 20.0f * Mathf.Log10(VoiceDetectionThreshold);
+            }
+            else if (VoiceDetectionThreshold == 0)
+            {
+                VoiceDetectionThreshold = 0.0f;
             }
 
             if (AutoStart)


### PR DESCRIPTION
Added functionality to fully disable WakeWordListener.

- Turn off `Auto Start` in WakeWordListener.
- Turn off `Control WakeWordListener in Dialog` in DialogController.

When both options are disabled, WakeWordListener will no longer start.

Note: Fixed a bug where the noise gate remained open when VoiceDetectionThreshold was set to 0 in WakeWordListener.