### PR TITLE
Provide workaround to clear state data, including LLM context

### DIFF
--- a/Scripts/Dialog/DialogController.cs
+++ b/Scripts/Dialog/DialogController.cs
@@ -569,6 +569,18 @@ namespace ChatdollKit.Dialog
             return dialogTokenSource.Token;
         }
 
+        public async UniTask ClearStateAsync(string userId = null)
+        {
+            if (requestProcessor is LocalRequestProcessor)
+            {
+                if (string.IsNullOrEmpty(userId))
+                {
+                    userId = GetClientIdDefault();
+                }
+                await ((LocalRequestProcessor)requestProcessor).ClearStateAsync(userId);
+            }           
+        }
+
         private void Update()
         {
             // Control mute

--- a/Scripts/Dialog/Processor/LocalRequestProcessor.cs
+++ b/Scripts/Dialog/Processor/LocalRequestProcessor.cs
@@ -151,5 +151,10 @@ namespace ChatdollKit.Dialog.Processor
                 throw ex;
             }
         }
+
+        public virtual async UniTask ClearStateAsync(string userId)
+        {
+            await StateStore.DeleteStateAsync(userId);
+        }
     }
 }


### PR DESCRIPTION
Execute `DialogController.ClearStateAsync()` to clear LLM context.