### PR TITLE
Add support for user-defined tags in response messages

### DIFF
--- a/Demo/Scripts/Main08.cs
+++ b/Demo/Scripts/Main08.cs
@@ -76,6 +76,36 @@ namespace ChatdollKit.Demo
             var faceOnStart = new List<FaceExpression>();
             faceOnStart.Add(new FaceExpression("Joy", 3.0f));
             modelController.SetFace(faceOnStart);
+
+            // User defined tag example: Dynamic multi language switching
+            // Insert following instruction to ChatGPTService.
+            // ----
+            // If you want change current language, insert language tag like [language:en-US].
+            //
+            // Example:
+            // [language:en-US]From now on, let's talk in English.
+            // ----
+            // var chatGPTService = gameObject.GetComponent<ChatGPTService>();
+            // chatGPTService.HandleExtractedTags = (tags, session) =>
+            // {
+            //     if (tags.ContainsKey("language"))
+            //     {
+            //         var language = tags["language"].Contains("-") ? tags["language"].Split('-')[0] : tags["language"];
+            //         if (language != "ja")
+            //         {
+            //             var openAITTS = gameObject.GetComponent<OpenAITTSLoader>();
+            //             modelController.RegisterTTSFunction(openAITTS.Name, openAITTS.GetAudioClipAsync, true);
+            //         }
+            //         else
+            //         {
+            //             var voicevoxTTS = gameObject.GetComponent<VoicevoxTTSLoader>();
+            //             modelController.RegisterTTSFunction(voicevoxTTS.Name, voicevoxTTS.GetAudioClipAsync, true);
+            //         }
+            //         var openAIListener = gameObject.GetComponent<OpenAISpeechListener>();
+            //         openAIListener.Language = language;
+            //         Debug.Log($"Set language to {language}");
+            //     }
+            // };
         }
 
         private void Update()

--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -342,6 +342,11 @@ namespace ChatdollKit.LLM.ChatGPT
 
             var extractedTags = ExtractTags(chatGPTSession.CurrentStreamBuffer);
 
+            if (extractedTags.Count > 0 && HandleExtractedTags != null)
+            {
+                HandleExtractedTags(extractedTags, chatGPTSession);
+            }
+
             if (CaptureImage != null && extractedTags.ContainsKey("vision") && chatGPTSession.IsVisionAvailable)
             {
                 // Prevent infinit loop

--- a/Scripts/LLM/LLMContentSkill.cs
+++ b/Scripts/LLM/LLMContentSkill.cs
@@ -19,6 +19,8 @@ namespace ChatdollKit.LLM
         public List<string> OptionalSplitChars = new List<string>() { "、", "," };
         public int MaxLengthBeforeOptionalSplit = 0;
 
+        public Action<string, AnimatedVoiceRequest> HandleSplittedText;
+
         protected ILLMService llmService { get; set; }
         protected List<AnimatedVoiceRequest> responseAnimations { get; set; } = new List<AnimatedVoiceRequest>();
         protected Dictionary<string, Model.Animation> animationsToPerform { get; set; } = new Dictionary<string, Model.Animation>();
@@ -153,6 +155,8 @@ namespace ChatdollKit.LLM
                                         Debug.LogWarning($"Animation {anim} is not registered.");
                                     }
                                 }
+
+                                HandleSplittedText?.Invoke(text, avreq);
 
                                 Debug.Log($"Assistant: {logMessage}");
 

--- a/Scripts/LLM/LLMServiceBase.cs
+++ b/Scripts/LLM/LLMServiceBase.cs
@@ -37,6 +37,7 @@ namespace ChatdollKit.LLM
         public int HistoryTurns = 10;
 
         public Action OnEnabled { get; set; }
+        public Action <Dictionary<string, string>, ILLMSession> HandleExtractedTags;
 
         public Func<ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
 


### PR DESCRIPTION
Implement support for user-defined tags in response messages. Related issue: #339

Usage

```csharp
// User defined tag example: Dynamic multi language switching
// Insert following instruction to ChatGPTService.
// ----
// If you want change current language, insert language tag like [language:en-US].
//
// Example:
// [language:en-US]From now on, let's talk in English.
// ----
var chatGPTService = gameObject.GetComponent<ChatGPTService>();
chatGPTService.HandleExtractedTags = (tags, session) =>
{
    if (tags.ContainsKey("language"))
    {
        var language = tags["language"].Contains("-") ? tags["language"].Split('-')[0] : tags["language"];
        if (language != "ja")
        {
            var openAITTS = gameObject.GetComponent<OpenAITTSLoader>();
            modelController.RegisterTTSFunction(openAITTS.Name, openAITTS.GetAudioClipAsync, true);
        }
        else
        {
            var voicevoxTTS = gameObject.GetComponent<VoicevoxTTSLoader>();
            modelController.RegisterTTSFunction(voicevoxTTS.Name, voicevoxTTS.GetAudioClipAsync, true);
        }
        var openAIListener = gameObject.GetComponent<OpenAISpeechListener>();
        openAIListener.Language = language;
        Debug.Log($"Set language to {language}");
    }
};
```