### PR TITLE
Add DialogPriorityManager for handling prioritized dialog requests

### DIFF
--- a/Scripts/AIAvatar.cs
+++ b/Scripts/AIAvatar.cs
@@ -343,7 +343,7 @@ namespace ChatdollKit
 
         public void StopChat()
         {
-            DialogProcessor.StopDialog();
+            _ = DialogProcessor.StopDialog();
         }
 
         public void AddProcessingPresentaion(List<Model.Animation> animations, List<FaceExpression> faces)
@@ -381,7 +381,7 @@ namespace ChatdollKit
             {
                 if (!string.IsNullOrEmpty(ExtractCancelWord(text)))
                 {
-                    DialogProcessor.StopDialog();
+                    await DialogProcessor.StopDialog();
                     Mode = AvatarMode.Idle;
                     modeTimer = idleTimeout;
                     return;

--- a/Scripts/Dialog/DialogPriorityManager.cs
+++ b/Scripts/Dialog/DialogPriorityManager.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using UnityEngine;
+using ChatdollKit.IO;
+
+namespace ChatdollKit.Dialog
+{
+    public class DialogPriorityManager : MonoBehaviour
+    {
+        private DialogProcessor dialogProcessor;
+        private PriorityQueue<DialogQueueItem> dialogQueue = new PriorityQueue<DialogQueueItem>();
+
+        [SerializeField]
+        private int idlingFrameThreshold = 2;
+        private int idlingFrameCount = 0;
+
+        private void Start()
+        {
+            dialogProcessor = gameObject.GetComponent<DialogProcessor>();
+        }
+
+        private void Update()
+        {
+            if (dialogProcessor == null) return;
+
+            if (dialogProcessor.Status == DialogProcessor.DialogStatus.Idling)
+            {
+                idlingFrameCount += 1;
+
+                if (idlingFrameCount >= idlingFrameThreshold)
+                {
+                    idlingFrameCount = 0;
+    
+                    if (!dialogQueue.IsEmpty())
+                    {
+                        var dialogRequest = dialogQueue.Dequeue();
+                        _ = dialogProcessor.StartDialogAsync(dialogRequest.Text, dialogRequest.Payloads);
+                    }
+                }
+            }
+            else
+            {
+                idlingFrameCount = 0;
+            }
+        }
+
+        public void SetRequest(string text, Dictionary<string, object> payloads = null, int priority = 10)
+        {
+            if (priority == 0)
+            {
+                _ = dialogProcessor.StartDialogAsync(text);
+            }
+            else
+            {
+                dialogQueue.Enqueue(new DialogQueueItem() {
+                    Priority = priority, Text = text, Payloads = payloads
+                }, priority);
+            }            
+        }
+
+        public void ClearDialogRequestQueue(int priority = 0)
+        {
+            dialogQueue.Clear(priority);
+        }
+
+        private class DialogQueueItem
+        {
+            public int Priority { get; set; }
+            public string Text { get; set; }
+            public Dictionary<string, object> Payloads { get; set; }
+        }
+    }
+}

--- a/Scripts/Dialog/DialogPriorityManager.cs.meta
+++ b/Scripts/Dialog/DialogPriorityManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dc99e2caa54e4dcea35af2226c166d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/IO/PriorityQueue.cs
+++ b/Scripts/IO/PriorityQueue.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ChatdollKit.IO
+{
+    public class PriorityQueue<T>
+    {
+        private SortedList<int, Queue<T>> priorityQueues;
+
+        public PriorityQueue()
+        {
+            priorityQueues = new SortedList<int, Queue<T>>();
+        }
+
+        public void Enqueue(T item, int priority)
+        {
+            if (!priorityQueues.ContainsKey(priority))
+            {
+                priorityQueues[priority] = new Queue<T>();
+            }
+            priorityQueues[priority].Enqueue(item);
+        }
+
+        public T Dequeue()
+        {
+            if (priorityQueues.Count == 0)
+            {
+                throw new System.InvalidOperationException("Queue is empty.");
+            }
+
+            var highestPriority = priorityQueues.Keys.Min();
+            var queue = priorityQueues[highestPriority];
+            var item = queue.Dequeue();
+
+            if (queue.Count == 0)
+            {
+                priorityQueues.Remove(highestPriority);
+            }
+
+            return item;
+        }
+
+        public bool IsEmpty()
+        {
+            return !priorityQueues.Any();
+        }
+
+        public List<T> PeekAll()
+        {
+            var items = new List<T>();
+            foreach (var queue in priorityQueues.Values)
+            {
+                items.AddRange(queue);
+            }
+            return items;
+        }
+
+        public bool Remove(T item)
+        {
+            foreach (var priority in priorityQueues.Keys.ToList())
+            {
+                var queue = priorityQueues[priority];
+
+                var tempQueue = new Queue<T>();
+                var found = false;
+
+                while (queue.Count > 0)
+                {
+                    var currentItem = queue.Dequeue();
+                    if (!found && currentItem.Equals(item))
+                    {
+                        found = true;
+                        continue;
+                    }
+                    tempQueue.Enqueue(currentItem);
+                }
+
+                if (tempQueue.Count > 0)
+                {
+                    priorityQueues[priority] = tempQueue;
+                }
+                else
+                {
+                    priorityQueues.Remove(priority);
+                }
+
+                if (found)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void Clear(int priority = 0)
+        {
+            if (priority == 0)
+            {
+                priorityQueues.Clear();
+            }
+            else
+            {
+                if (priorityQueues.ContainsKey(priority))
+                {
+                    priorityQueues.Remove(priority);
+                }
+            }
+        }
+    }
+}

--- a/Scripts/IO/PriorityQueue.cs.meta
+++ b/Scripts/IO/PriorityQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 563de7237cab042fe92a513b0ff64a4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Introduced `DialogPriorityManager` class to manage dialog requests based on priority levels. The manager can interrupt ongoing conversations or queue new ones for later, depending on the priority set in `SetRequest`. High-priority requests can immediately start, while lower-priority ones are queued and processed when idle. Queued dialogs can also be interrupted based on priority.

Addresses issue #341.