### PR TITLE
Add option to hide user message window

### DIFF
--- a/Scripts/AIAvatar.cs
+++ b/Scripts/AIAvatar.cs
@@ -119,7 +119,7 @@ namespace ChatdollKit
                 }
 
                 // Show user message
-                if (!string.IsNullOrEmpty(text))
+                if (UserMessageWindow != null && !string.IsNullOrEmpty(text))
                 {
                     await UserMessageWindow.ShowMessageAsync(text, token);
                 }
@@ -216,7 +216,7 @@ namespace ChatdollKit
                             minRecordingDuration: conversationMinRecordingDuration,
                             maxRecordingDuration: conversationMaxRecordingDuration
                         );
-                        UserMessageWindow.Show("Listening...");                        
+                        UserMessageWindow?.Show("Listening...");    
                     }
                 }
                 else
@@ -228,7 +228,7 @@ namespace ChatdollKit
                             minRecordingDuration: idleMinRecordingDuration,
                             maxRecordingDuration: idleMaxRecordingDuration
                         );
-                        UserMessageWindow.Hide();
+                        UserMessageWindow?.Hide();
                     }
                 }
             }


### PR DESCRIPTION
Implemented the ability to hide the user message window in the AIAvatar component. This prevents displaying unwanted text when receiving commands from external programs. If the `UserMessageWindow` is not assigned in the AIAvatar component, user messages will not be shown.

Related issue: #340