### PR TITLE
Improve text splitting logic in SplitString method

### DIFF
--- a/Scripts/LLM/LLMContentSkill.cs
+++ b/Scripts/LLM/LLMContentSkill.cs
@@ -198,8 +198,18 @@ namespace ChatdollKit.LLM
 
                 if (IsSplitChar(input[i].ToString()))
                 {
-                    result.Add(tempBuffer);
-                    tempBuffer = "";
+                    // Check if the next character is also a split character
+                    if (i + 1 < input.Length && IsSplitChar(input[i + 1].ToString()))
+                    {
+                        // Continue the buffer if the next character is also a split character
+                        continue;
+                    }
+                    else
+                    {
+                        // Add to result if it's the end of the sequence of split characters
+                        result.Add(tempBuffer);
+                        tempBuffer = "";
+                    }
                 }
                 else if (IsOptionalSplitChar(input[i].ToString()))
                 {

--- a/Scripts/Model/ModelRequestBroker.cs
+++ b/Scripts/Model/ModelRequestBroker.cs
@@ -183,8 +183,18 @@ namespace ChatdollKit.Model
 
                 if (IsSplitChar(input[i].ToString()))
                 {
-                    result.Add(tempBuffer);
-                    tempBuffer = "";
+                    // Check if the next character is also a split character
+                    if (i + 1 < input.Length && IsSplitChar(input[i + 1].ToString()))
+                    {
+                        // Continue the buffer if the next character is also a split character
+                        continue;
+                    }
+                    else
+                    {
+                        // Add to result if it's the end of the sequence of split characters
+                        result.Add(tempBuffer);
+                        tempBuffer = "";
+                    }
                 }
                 else if (IsOptionalSplitChar(input[i].ToString()))
                 {


### PR DESCRIPTION
Modified the SplitString method to treat consecutive delimiters as a single unit.

- Added logic in the SplitString method to check if delimiters are consecutive.
- When consecutive delimiters are detected, they are treated as part of the same buffer and only split once the sequence ends.
- This ensures that strings like "Hello! How are you?!" are split into "Hello!" and "How are you?!", as intended.

This fix improves the behavior when handling text with consecutive punctuation marks, ensuring more accurate splitting.