### PR TITLE
Improve TTS handling for empty strings and errors

### DIFF
--- a/Extension/Azure/AzureTTSLoader.cs
+++ b/Extension/Azure/AzureTTSLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -95,18 +96,18 @@ namespace ChatdollKit.Extension.Azure
                 www.uploadHandler = new UploadHandlerRaw(data);
 
                 // Send request
-                await www.SendWebRequest();
+                try
+                {
+                    await www.SendWebRequest().ToUniTask(cancellationToken: token);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error occured while processing Azure text-to-speech: {ex}");
+                    return null;
+                }
 
-                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
-                {
-                    Debug.LogError($"Error occured while processing text-to-speech voice: {www.error}");
-                }
-                else if (www.isDone)
-                {
-                    return DownloadHandlerAudioClip.GetContent(www);
-                }
+                return DownloadHandlerAudioClip.GetContent(www);
             }
-            return null;
         }
 
         protected async UniTask<AudioClip> DownloadAudioClipWebGLAsync(string url, byte[] data, Dictionary<string, string> headers, CancellationToken token)

--- a/Extension/Dify/DifyTTSLoader.cs
+++ b/Extension/Dify/DifyTTSLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -75,18 +76,17 @@ namespace ChatdollKit.Extension.Dify
 
                 www.uploadHandler = new UploadHandlerRaw(data);
 
-                await www.SendWebRequest().ToUniTask();
-
-                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
+                try
                 {
-                    Debug.LogError($"Error occured while processing text-to-speech voice: {www.error}");
+                    await www.SendWebRequest().ToUniTask(cancellationToken: token);
                 }
-                else if (www.isDone)
+                catch (Exception ex)
                 {
-                    return DownloadHandlerAudioClip.GetContent(www);
+                    Debug.LogError($"Error occured while processing Dify text-to-speech: {ex}");
+                    return null;
                 }
+                return DownloadHandlerAudioClip.GetContent(www);
             }
-            return null;
         }
     }
 }

--- a/Extension/Google/GoogleTTSLoader.cs
+++ b/Extension/Google/GoogleTTSLoader.cs
@@ -45,6 +45,7 @@ namespace ChatdollKit.Extension.Google
             SpeakerName = string.IsNullOrEmpty(SpeakerName) || overwrite ? speakerName : SpeakerName;
         }
 
+        // See https://cloud.google.com/text-to-speech/docs/voices
         protected override async UniTask<AudioClip> DownloadAudioClipAsync(Voice voice, CancellationToken token)
         {
             if (token.IsCancellationRequested) { return null; };

--- a/Extension/OpenAI/OpenAITTSLoader.cs
+++ b/Extension/OpenAI/OpenAITTSLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -87,18 +88,18 @@ namespace ChatdollKit.Extension.OpenAI
 
                 www.uploadHandler = new UploadHandlerRaw(data);
 
-                await www.SendWebRequest().ToUniTask();
+                try
+                {
+                    await www.SendWebRequest().ToUniTask(cancellationToken: token);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error occured while processing OpenAI text-to-speech: {ex}");
+                    return null;
+                }
 
-                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
-                {
-                    Debug.LogError($"Error occured while processing text-to-speech voice: {www.error}");
-                }
-                else if (www.isDone)
-                {
-                    return DownloadHandlerAudioClip.GetContent(www);
-                }
+                return DownloadHandlerAudioClip.GetContent(www);
             }
-            return null;
         }
 
         protected async UniTask<AudioClip> DownloadAudioClipWebGLAsync(string url, byte[] data, Dictionary<string, string> headers, CancellationToken token)

--- a/Extension/StyleBertVits2/StyleBertVits2TTSLoader.cs
+++ b/Extension/StyleBertVits2/StyleBertVits2TTSLoader.cs
@@ -121,19 +121,18 @@ namespace ChatdollKit.Extension.StyleBertVits2
                 www.timeout = Timeout;
                 www.method = "GET";
 
-                // Send request
-                await www.SendWebRequest();
+                try
+                {
+                    await www.SendWebRequest().ToUniTask(cancellationToken: token);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error occured while processing StyleBertVits2 text-to-speech: {ex}");
+                    return null;
+                }
 
-                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
-                {
-                    Debug.LogError($"Error occured while processing StyleBertVits2 text-to-speech: {www.error}");
-                }
-                else if (www.isDone)
-                {
-                    return DownloadHandlerAudioClip.GetContent(www);
-                }
+                return DownloadHandlerAudioClip.GetContent(www);
             }
-            return null;
         }
 
         protected async UniTask<AudioClip> DownloadAudioClipWebGLAsync(string url, CancellationToken token)

--- a/Extension/Voiceroid/VoiceroidTTSLoader.cs
+++ b/Extension/Voiceroid/VoiceroidTTSLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -99,18 +100,18 @@ namespace ChatdollKit.Extension
                 www.SetRequestHeader("Content-Type", headers["Content-Type"]);
                 www.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(request)));
 
-                await www.SendWebRequest().ToUniTask();
+                try
+                {
+                    await www.SendWebRequest().ToUniTask(cancellationToken: token);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error occured while processing VOICEROID text-to-speech: {ex}");
+                    return null;
+                }
 
-                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
-                {
-                    Debug.LogError($"Error occured while processing voiceroid text-to-speech: {www.error}");
-                }
-                else if (www.isDone)
-                {
-                    return DownloadHandlerAudioClip.GetContent(www);
-                }
+                return DownloadHandlerAudioClip.GetContent(www);
             }
-            return null;
         }
 
         private async UniTask<AudioClip> DownloadAudioClipWebGLAsync(VoiceroidRequest request, Dictionary<string, string> headers, CancellationToken token)

--- a/Extension/Voicevox/VoicevoxTTSLoader.cs
+++ b/Extension/Voicevox/VoicevoxTTSLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using UnityEngine;
@@ -100,18 +101,18 @@ namespace ChatdollKit.Extension.Voicevox
                 www.uploadHandler = new UploadHandlerRaw(data);
 
                 // Send request
-                await www.SendWebRequest();
+                try
+                {
+                    await www.SendWebRequest().ToUniTask(cancellationToken: token);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error occured while processing VOICEVOX text-to-speech: {ex}");
+                    return null;
+                }
 
-                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
-                {
-                    Debug.LogError($"Error occured while processing voicevox text-to-speech: {www.error}");
-                }
-                else if (www.isDone)
-                {
-                    return DownloadHandlerAudioClip.GetContent(www);
-                }
+                return DownloadHandlerAudioClip.GetContent(www);
             }
-            return null;
         }
 
         protected async UniTask<AudioClip> DownloadAudioClipWebGLAsync(string url, byte[] data, Dictionary<string, string> headers, CancellationToken token)

--- a/Extension/Watson/WatsonTTSLoader.cs
+++ b/Extension/Watson/WatsonTTSLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -89,18 +90,18 @@ namespace ChatdollKit.Extension.Watson
                 www.uploadHandler = new UploadHandlerRaw(data);
 
                 // Send request
-                await www.SendWebRequest().ToUniTask();
+                try
+                {
+                    await www.SendWebRequest().ToUniTask(cancellationToken: token);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"Error occured while processing Watson text-to-speech: {ex}");
+                    return null;
+                }
 
-                if (www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError)
-                {
-                    Debug.LogError($"Error occured while processing text-to-speech voice: {www.error}");
-                }
-                else if (www.isDone)
-                {
-                    return DownloadHandlerAudioClip.GetContent(www);
-                }
+                return DownloadHandlerAudioClip.GetContent(www);
             }
-            return null;
         }
 
         protected async UniTask<AudioClip> DownloadAudioClipWebGLAsync(string url, byte[] data, Dictionary<string, string> headers, CancellationToken token)

--- a/Scripts/Model/WebVoiceLoaderBase.cs
+++ b/Scripts/Model/WebVoiceLoaderBase.cs
@@ -29,6 +29,11 @@ namespace ChatdollKit.Model
 
         public async UniTask<AudioClip> GetAudioClipAsync(Voice voice, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(voice.Text.Trim()))
+            {
+                return null;
+            }
+
             if (IsLoading(voice))
             {
                 // Wait for cache is ready or task is canceled


### PR DESCRIPTION
- Skip processing when the input is an empty string, avoiding unnecessary synthesis attempts and its warnings as results.
- Improved error handling by API call errors within TTSLoader, preventing unintended propagation.

Related issue: #352 