### PR TITLE
Enable WebGL interaction via external JavaScript

### DIFF
--- a/Plugins/JavaScriptMessageHandler.jslib
+++ b/Plugins/JavaScriptMessageHandler.jslib
@@ -1,0 +1,10 @@
+mergeInto(LibraryManager.library, {
+    InitJSMessageHandler: function(targetObjectNamePtr, targetFunctionNamePtr) {
+        let targetObjectName = UTF8ToString(targetObjectNamePtr);
+        let targetFunctionName = UTF8ToString(targetFunctionNamePtr);
+        window.SendMessageToChatdollKit = (message) => {
+            console.log("Send message to ChatdollKit: " + message);
+            SendMessage(targetObjectName, targetFunctionName, message);
+        };
+    }
+});

--- a/Plugins/JavaScriptMessageHandler.jslib.meta
+++ b/Plugins/JavaScriptMessageHandler.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 22b027126ba1c4e7a8bfad4679969aac
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/IO/ExternalInboundMessage.cs
+++ b/Scripts/IO/ExternalInboundMessage.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace ChatdollKit.IO
+{
+    public class ExternalInboundMessage
+    {
+        public string Endpoint { get; set; }
+        public string Operation { get; set; }
+        public int Priority { get; set; }
+        public string Text { get; set; }
+        public Dictionary<string, object> Payloads { get; set; }
+    }
+}

--- a/Scripts/IO/ExternalInboundMessage.cs.meta
+++ b/Scripts/IO/ExternalInboundMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b782d33e07a74dbcb846a27942238c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/IO/IExternalInboundMessageHandler.cs
+++ b/Scripts/IO/IExternalInboundMessageHandler.cs
@@ -1,0 +1,10 @@
+using System;
+using Cysharp.Threading.Tasks;
+
+namespace ChatdollKit.IO
+{
+    public interface IExternalInboundMessageHandler
+    {
+        Func<ExternalInboundMessage, UniTask> OnDataReceived { get; set; }
+    }
+}

--- a/Scripts/IO/IExternalInboundMessageHandler.cs.meta
+++ b/Scripts/IO/IExternalInboundMessageHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1475e0a6781a94d2595617729559fdc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/IO/JavaScriptMessageHandler.cs
+++ b/Scripts/IO/JavaScriptMessageHandler.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace ChatdollKit.IO
+{
+    public class JavaScriptMessageHandler : MonoBehaviour, IExternalInboundMessageHandler
+    {
+        public Func<ExternalInboundMessage, UniTask> OnDataReceived { get; set; }
+
+#if UNITY_WEBGL
+        [DllImport("__Internal")]
+        private static extern void InitJSMessageHandler(string targetObjectName, string targetFunctionName);
+
+        [SerializeField]
+        private bool captureKeyboardInput = true;
+        [SerializeField]
+        private bool isDebug;
+
+        public void Start()
+        {
+#if !UNITY_EDITOR
+            if (captureKeyboardInput)
+            {
+                WebGLInput.captureAllKeyboardInput = false;
+            }
+
+            InitJSMessageHandler(gameObject.name, "HandleMessageFromJavaScript");
+#endif
+        }
+
+        public void HandleMessageFromJavaScript(string message)
+        {
+            try
+            {
+                if (isDebug)
+                {
+                    Debug.Log($"Received from JavaScript: {message}");
+                }
+
+                var jsMessage = JsonConvert.DeserializeObject<ExternalInboundMessage>(message);
+                OnDataReceived?.Invoke(jsMessage);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Error at HandleMessageFromJavaScript: {ex.Message}");
+            }
+        }
+#endif
+    }
+}

--- a/Scripts/IO/JavaScriptMessageHandler.cs.meta
+++ b/Scripts/IO/JavaScriptMessageHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d2f2842e4de74613a697121cab4eb84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Added support for controlling the ChatdollKit Unity app from external JavaScript in WebGL builds.
- Attach `JavaScriptMessageHandler` component to the AIAvatar object to allow message sending from JavaScript using the `SendMessageToChatdollKit` function.
- Implement `JavaScriptMessageHandler.OnDataReceived` to handle incoming messages.
- Unified `JavaScriptMessageHandler` and `SocketServer` by implementing `IExternalInboundMessageHandler` for both, ensuring they receive messages as `ExternalInboundMessage`.

Related issue: #340