### PR TITLE
Migrate to LLMService Context Management

### DIFF
--- a/Plugins/ClaudeServiceWebGL.jslib
+++ b/Plugins/ClaudeServiceWebGL.jslib
@@ -16,6 +16,7 @@ mergeInto(LibraryManager.library, {
                 "anthropic-version": "2023-06-01",
                 "anthropic-beta": "messages-2023-12-15",
                 "Content-Type": "application/json",
+                "anthropic-dangerous-direct-browser-access": "true",
                 "x-api-key": `${apiKey}`
             },
             method: "POST",

--- a/Scripts/LLM/CommandR/CommandRServiceWebGL.cs
+++ b/Scripts/LLM/CommandR/CommandRServiceWebGL.cs
@@ -32,7 +32,7 @@ namespace ChatdollKit.LLM.CommandR
         protected bool isChatCompletionJSDone { get; set; } = false;
         protected Dictionary<string, CommandRSession> sessions { get; set; } = new Dictionary<string, CommandRSession>();
 
-        public override async UniTask StartStreamingAsync(string inputText, List<CommandRToolResult> toolResults, CommandRSession commandRSession, Dictionary<string, object> stateData, Dictionary<string, string> customParameters, Dictionary<string, string> customHeaders, bool useFunctions = true, CancellationToken token = default)
+        public override async UniTask StartStreamingAsync(string inputText, List<CommandRToolResult> toolResults, CommandRSession commandRSession, Dictionary<string, string> customParameters, Dictionary<string, string> customHeaders, bool useFunctions = true, CancellationToken token = default)
         {
             commandRSession.CurrentStreamBuffer = string.Empty;
             commandRSession.PartialStreamEndChunk = string.Empty;
@@ -95,7 +95,7 @@ namespace ChatdollKit.LLM.CommandR
             }
 
             // TODO: Support custom headers later...
-            if (customHeaders.Count >= 0)
+            if (customHeaders.Count > 0)
             {
                 Debug.LogWarning("Custom headers for Command R on WebGL is not supported for now.");
             }
@@ -160,7 +160,7 @@ namespace ChatdollKit.LLM.CommandR
             // Update histories
             if (commandRSession.ResponseType != ResponseType.Error && commandRSession.ResponseType != ResponseType.Timeout)
             {
-                await AddHistoriesAsync(commandRSession, stateData, token);
+                UpdateContext(commandRSession);
             }
             else
             {

--- a/Scripts/LLM/LLMRouter.cs
+++ b/Scripts/LLM/LLMRouter.cs
@@ -107,13 +107,12 @@ namespace ChatdollKit.LLM
             return llmFunctionSkills;
         }
 
-        public override async UniTask<IntentExtractionResult> ExtractIntentAsync(Request request, State state, CancellationToken token)
+        public override async UniTask<IntentExtractionResult> ExtractIntentAsync(Request request, State _, CancellationToken token)
         {
             var payloads = new Dictionary<string, object>();
             payloads.Add("RequestPayloads", request.Payloads);
-            payloads.Add("StateData", state.Data);
 
-            var messages = await llmService.MakePromptAsync(state.UserId, request.Text, payloads, token);
+            var messages = await llmService.MakePromptAsync("_", request.Text, payloads, token);
 
             var llmSession = await llmService.GenerateContentAsync(messages, payloads, token: token);
             llmSession.OnStreamingEnd = async () =>
@@ -134,6 +133,11 @@ namespace ChatdollKit.LLM
             }
 
             return new IntentExtractionResult(contentSkillName.ToLower(), Priority.Normal);
+        }
+
+        public override ISkill Route(Request request, State _, CancellationToken token)
+        {
+            return topicResolver[request.Intent.Name];
         }
     }
 }


### PR DESCRIPTION
Removed dependency on legacy state management and introduced individual context management for each LLMService. This change allows each service to manage its own context separately.

There is no fundamental change to the external interface. However, if your implementation relied on legacy state deletions to clear context, you will need to modify your code to use the `ClearContext()` method of LLMService.