### PR TITLE
Introduce LLMServiceExtensions for Centralized Custom Processing

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -30,8 +30,6 @@ namespace ChatdollKit.LLM.ChatGPT
         [SerializeField]
         protected float noDataResponseTimeoutSec = 5.0f;
 
-        public Func<string, UniTask<byte[]>> CaptureImage = null;
-
         protected JsonSerializerSettings messageSerializationSettings = new JsonSerializerSettings
         {
             TypeNameHandling = TypeNameHandling.All
@@ -176,10 +174,10 @@ namespace ChatdollKit.LLM.ChatGPT
             {
                 data.Add("max_tokens", MaxTokens);
             }
-            if (useFunctions && llmTools.Count > 0 && !Model.ToLower().Contains("vision"))
+            if (useFunctions && Tools.Count > 0 && !Model.ToLower().Contains("vision"))
             {
                 var tools = new List<Dictionary<string, object>>();
-                foreach (var tool in llmTools)
+                foreach (var tool in Tools)
                 {
                     tools.Add(new Dictionary<string, object>()
                     {

--- a/Scripts/LLM/Claude/ClaudeService.cs
+++ b/Scripts/LLM/Claude/ClaudeService.cs
@@ -27,8 +27,6 @@ namespace ChatdollKit.LLM.Claude
         [SerializeField]
         protected float noDataResponseTimeoutSec = 5.0f;
 
-        public Func<string, UniTask<byte[]>> CaptureImage = null;
-
         public override ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null)
         {
             if (role == "user")
@@ -146,10 +144,10 @@ namespace ChatdollKit.LLM.Claude
                 { "stream", true },
             };
 
-            if (llmTools.Count > 0) // tools must be included when tool_result
+            if (Tools.Count > 0) // tools must be included when tool_result
             {
                 var claudeTools = new List<ClaudeTool>();
-                foreach (var tool in llmTools)
+                foreach (var tool in Tools)
                 {
                     claudeTools.Add(new ClaudeTool(tool));
                 }

--- a/Scripts/LLM/CommandR/CommandRService.cs
+++ b/Scripts/LLM/CommandR/CommandRService.cs
@@ -32,8 +32,6 @@ namespace ChatdollKit.LLM.CommandR
         [SerializeField]
         protected float noDataResponseTimeoutSec = 5.0f;
 
-        public Func<string, UniTask<byte[]>> CaptureImage = null;
-
         public override ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null)
         {
             if (role == "user")
@@ -169,10 +167,10 @@ namespace ChatdollKit.LLM.CommandR
                 data["tool_results"] = toolResults;
             }
 
-            if (llmTools.Count > 0)
+            if (Tools.Count > 0)
             {
                 var commandRTools = new List<CommandRTool>();
-                foreach (var tool in llmTools)
+                foreach (var tool in Tools)
                 {
                     commandRTools.Add(new CommandRTool(tool));
                 }

--- a/Scripts/LLM/Dify/DifyService.cs
+++ b/Scripts/LLM/Dify/DifyService.cs
@@ -25,7 +25,6 @@ namespace ChatdollKit.LLM.Dify
 
         protected string currentConversationId;
         protected string conversationIdKey = "DifyConversationId";
-        public Func<string, UniTask<byte[]>> CaptureImage = null;
 
         public string GetConversationId()
         {

--- a/Scripts/LLM/Gemini/GeminiService.cs
+++ b/Scripts/LLM/Gemini/GeminiService.cs
@@ -27,8 +27,6 @@ namespace ChatdollKit.LLM.Gemini
         [SerializeField]
         protected float noDataResponseTimeoutSec = 10.0f;   // Some requests like multi-modal takes time longer
 
-        public Func<string, UniTask<byte[]>> CaptureImage = null;
-
         public override ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null)
         {
             return new GeminiMessage(
@@ -177,11 +175,11 @@ namespace ChatdollKit.LLM.Gemini
             }
 
             // Set tools. Multimodal model doesn't support function calling for now (2023.12.29)
-            if (useFunctions && llmTools.Count > 0 && !Model.ToLower().Contains("vision"))
+            if (useFunctions && Tools.Count > 0 && !Model.ToLower().Contains("vision"))
             {
                  data.Add("tools", new List<Dictionary<string, object>>(){
                      new Dictionary<string, object> {
-                         { "function_declarations", llmTools }
+                         { "function_declarations", Tools }
                      }
                  });
             }

--- a/Scripts/LLM/ILLMService.cs
+++ b/Scripts/LLM/ILLMService.cs
@@ -9,11 +9,13 @@ namespace ChatdollKit.LLM
     {
         bool IsEnabled { get; set; }
         Action OnEnabled { get; set; }
-        bool AddTool(ILLMTool tool);
+        List<ILLMTool> Tools { get; set; }
         UniTask<List<ILLMMessage>> MakePromptAsync(string userId, string inputText, Dictionary<string, object> payloads, CancellationToken token = default);
         UniTask<ILLMSession> GenerateContentAsync(List<ILLMMessage> messages, Dictionary<string, object> payloads = null, bool useFunctions = true, int retryCounter = 1, CancellationToken token = default);
         ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null);
         Func<ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
+        Action <Dictionary<string, string>, ILLMSession> HandleExtractedTags { get; set; }
+        Func<string, UniTask<byte[]>> CaptureImage { get; set; }
     }
 
     public enum ResponseType

--- a/Scripts/LLM/LLMServiceBase.cs
+++ b/Scripts/LLM/LLMServiceBase.cs
@@ -47,11 +47,10 @@ namespace ChatdollKit.LLM
         protected List<ILLMMessage> context = new List<ILLMMessage>();
 
         public Action OnEnabled { get; set; }
-        public Action <Dictionary<string, string>, ILLMSession> HandleExtractedTags;
-
+        public Action <Dictionary<string, string>, ILLMSession> HandleExtractedTags { get; set; }
+        public Func<string, UniTask<byte[]>> CaptureImage { get; set; }
         public Func<ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
-
-        protected List<ILLMTool> llmTools = new List<ILLMTool>();
+        public List<ILLMTool> Tools { get; set; } = new List<ILLMTool>();
 
         public virtual List<ILLMMessage> GetContext(int count)
         {
@@ -78,19 +77,6 @@ namespace ChatdollKit.LLM
         {
             context.Clear();
             contextUpdatedAt = Time.time;
-        }
-
-        public virtual bool AddTool(ILLMTool tool)
-        {
-            if (llmTools.Contains(tool))
-            {
-                return false;
-            }
-            else
-            {
-                llmTools.Add(tool);
-                return true;
-            }
         }
 
 #pragma warning disable CS1998


### PR DESCRIPTION
Added LLMServiceExtensions as a new mechanism for centralized custom processing across LLM services. By holding LLMServiceExtensions in DialogProcessor, this structure enables consistent application of custom handling—such as response modifications and image capture - regardless of which LLMService (e.g., ChatGPTService, ClaudeService) is in use.

- Introduced LLMServiceExtensions to manage common custom processing tasks in a centralized location
- Ensures that custom handling remains consistent even when switching between LLM services
- Simplifies configuration and promotes reusability across services

This update enhances flexibility and maintainability by allowing unified custom processing for all integrated LLM services.

Also improve LLMService and their tools selection process.