### PR TITLE
Support getting and clearing LLM context through DialogProcessor

### DIFF
--- a/Scripts/Dialog/DialogProcessor.cs
+++ b/Scripts/Dialog/DialogProcessor.cs
@@ -264,6 +264,17 @@ namespace ChatdollKit.Dialog
             }
         }
 
+        // LLM Context management
+        public List<ILLMMessage> GetContext(int count)
+        {
+            return llmService?.GetContext(count);
+        }
+
+        public void ClearContext()
+        {
+            llmService?.ClearContext();
+        }
+
         // Get cancellation token for tasks invoked in chat
         public CancellationToken GetDialogToken()
         {

--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -98,7 +98,7 @@ namespace ChatdollKit.LLM.ChatGPT
             }
 
             // Histories
-            messages.AddRange(GetContext(historyTurns));
+            messages.AddRange(GetContext(historyTurns * 2));
 
             // User (current input)
             if (((Dictionary<string, object>)payloads["RequestPayloads"]).ContainsKey("imageBytes"))

--- a/Scripts/LLM/Claude/ClaudeService.cs
+++ b/Scripts/LLM/Claude/ClaudeService.cs
@@ -78,7 +78,7 @@ namespace ChatdollKit.LLM.Claude
             // System - Claude takes system message outside of message parameter
 
             // Histories
-            messages.AddRange(GetContext(historyTurns));
+            messages.AddRange(GetContext(historyTurns * 2));
 
             if (((Dictionary<string, object>)payloads["RequestPayloads"]).ContainsKey("imageBytes"))
             {

--- a/Scripts/LLM/CommandR/CommandRService.cs
+++ b/Scripts/LLM/CommandR/CommandRService.cs
@@ -78,7 +78,7 @@ namespace ChatdollKit.LLM.CommandR
             }
 
             // Histories
-            messages.AddRange(GetContext(historyTurns));
+            messages.AddRange(GetContext(historyTurns * 2));
 
             // Text message (This message will be removed before sending request)
             messages.Add(new CommandRMessage("USER", inputText));

--- a/Scripts/LLM/ILLMService.cs
+++ b/Scripts/LLM/ILLMService.cs
@@ -10,6 +10,8 @@ namespace ChatdollKit.LLM
         bool IsEnabled { get; set; }
         Action OnEnabled { get; set; }
         List<ILLMTool> Tools { get; set; }
+        List<ILLMMessage> GetContext(int count);
+        void ClearContext();
         UniTask<List<ILLMMessage>> MakePromptAsync(string userId, string inputText, Dictionary<string, object> payloads, CancellationToken token = default);
         UniTask<ILLMSession> GenerateContentAsync(List<ILLMMessage> messages, Dictionary<string, object> payloads = null, bool useFunctions = true, int retryCounter = 1, CancellationToken token = default);
         ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null);

--- a/Scripts/LLM/LLMServiceBase.cs
+++ b/Scripts/LLM/LLMServiceBase.cs
@@ -60,7 +60,7 @@ namespace ChatdollKit.LLM
             }
 
             // Return copy not to update context directly
-            return context.Skip(context.Count - count * 2).ToList();
+            return context.Skip(context.Count - count).ToList();
         }
 
         public virtual List<ILLMMessage> GetContextRaw()


### PR DESCRIPTION
Add `List<ILLMMessage> GetContext(int count)` and `void ClearContext()` to `DialogProcessor`.
Also updated the `GetContext` to return a specified number of message entries instead of conversation turns. Previously, when an integer was passed to `count`, it returned the equivalent number of turns, each containing multiple messages (e.g., 2 turns resulted in 4 messages). Now, `GetContext` will return only the specified number of individual messages, aligning more intuitively with the `count` parameter.