### PR TITLE
Enable Chain of Thought Prompting

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -379,6 +379,15 @@ gameObject.GetComponent<ChatGPTService>().CaptureImage = async (source) =>
 ```
 
 
+### Chain of Thought Prompting
+
+Chain of Thought (CoT) プロンプティングはAIのパフォーマンスを向上させる手法です。コンセプトとその適用例についてはAnthropicの解説を参照してください。 https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/chain-of-thought .
+
+ChatdollKitはこのCoTの手法に、`<thinking> ~ </thinking>`の中身を読み上げの対象外とすることで対応しています。
+
+また、`LLMContentProcessor`のインスペクターの`ThinkTag`でタグの中の文字列をカスタマイズすることも可能です（reason、など）。
+
+
 ## 🗣️ Speech Synthesizer (Text-to-Speech)
 
 音声合成サービスとしてクラウドサービスとして提供されるGoogle、Azure、OpenAI、Watsonをサポートするほか、キャラクターとしてより魅力的な音声を提供するVOICEVOX、VOICEROID、Style-Bert-VITS2をサポートします。

--- a/README.md
+++ b/README.md
@@ -385,6 +385,15 @@ gameObject.GetComponent<ChatGPTService>().CaptureImage = async (source) =>
 ```
 
 
+### Chain of Thought Prompting
+
+Chain of Thought (CoT) prompting is a technique to enhance AI performance. For more information about CoT and examples of prompts, see https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/chain-of-thought .
+
+ChatdollKit supports Chain of Thought by excluding sentences wrapped in `<thinking> ~ </thinking>` tags from speech synthesis.
+
+You can customize the tag by setting a preferred word (e.g., "reason") as the `ThinkTag` in the inspector of `LLMContentProcessor`.
+
+
 ## 🗣️ Speech Synthesizer (Text-to-Speech)
 
 We support cloud-based speech synthesis services such as Google, Azure, OpenAI, and Watson, in addition to VOICEVOX, VOICEROID, and Style-Bert-VITS2 for more characterful and engaging voices. To use a speech synthesis service, attach `SpeechSynthesizer` from `ChatdollKit/Scripts/SpeechListener` to the AIAvatar object and check the `IsEnabled` box. If other `SpeechSynthesizer` components are attached, make sure to uncheck the `IsEnabled` box for those not in use.


### PR DESCRIPTION
Added support for Chain of Thought Prompting (CoT) to improve response accuracy and nuance in AI-driven conversations. 
LLM responses now exclude text wrapped in <thinking>...</thinking> tags from being read aloud, allowing the AI to 'think' silently when necessary.
The tag used to mark non-verbal thoughts is configurable via the `ThinkTag` property in `LLMContentProcessor.`