### PR TITLE
Add FileLogger to AITuber Demo

### DIFF
--- a/Demo/AITuber/AITuber.unity
+++ b/Demo/AITuber/AITuber.unity
@@ -825,6 +825,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2779731071012727286, guid: 74e8f3777a3aa42ba9447b4bec832cd1, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1886433103}
+    - targetCorrespondingSourceObject: {fileID: 2779731071012727286, guid: 74e8f3777a3aa42ba9447b4bec832cd1, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1886433104}
   m_SourcePrefab: {fileID: 100100000, guid: 74e8f3777a3aa42ba9447b4bec832cd1, type: 3}
 --- !u!1 &1886433055 stripped
 GameObject:
@@ -994,6 +997,19 @@ MonoBehaviour:
   animationCollectionKey: 0
   autoPilot: 0
   AutoPilotRequestText: "!\u30E6\u30FC\u30B6\u30FC\u304B\u3089\u306E\u30B3\u30E1\u30F3\u30C8\u304C\u306A\u3044\u306E\u3067\u3001\u767A\u8A00\u3092\u7D9A\u3051\u3066\u304F\u3060\u3055\u3044\u3002"
+--- !u!114 &1886433104
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886433055}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6da9993ba3234136b66e0cf46791be1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  logFilePrefix: AITuber
 --- !u!1 &1934380956
 GameObject:
   m_ObjectHideFlags: 0

--- a/Demo/AITuber/FileLogger.cs
+++ b/Demo/AITuber/FileLogger.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace ChatdollKit.Demo
+{
+    public class FileLogger : MonoBehaviour
+    {
+        [SerializeField]
+        private string logFilePrefix = "AITuber";
+        private string logFilePath;
+        private StreamWriter writer;
+        
+        private void Awake()
+        {
+            #if UNITY_EDITOR || UNITY_STANDALONE_WIN
+                var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Application.productName);
+            #elif UNITY_STANDALONE_OSX
+                var directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Logs", Application.productName);
+            #endif
+
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            logFilePath = Path.Combine(directory, $"{logFilePrefix}_{timestamp}.txt");
+
+            Debug.Log($"Log file: {logFilePath}");
+
+            writer = new StreamWriter(logFilePath, true);
+            writer.AutoFlush = true;
+
+            Application.logMessageReceived += HandleLog;
+        }
+
+        private void HandleLog(string logString, string stackTrace, LogType type)
+        {
+            if (writer == null) return;
+
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            
+            var prefix = type switch
+            {
+                LogType.Error => "[ERROR]",
+                LogType.Assert => "[ASSERT]",
+                LogType.Warning => "[WARNING]",
+                LogType.Log => "[INFO]",
+                LogType.Exception => "[EXCEPTION]",
+                _ => "[UNKNOWN]"
+            };
+
+            string message = $"{timestamp} {prefix} {logString}";
+            
+            if (type == LogType.Error || type == LogType.Exception)
+            {
+                message += $"\n{stackTrace}";
+            }
+
+            writer.WriteLine(message);
+        }
+
+        private void OnDestroy()
+        {
+            Application.logMessageReceived -= HandleLog;
+            
+            if (writer != null)
+            {
+                writer.Close();
+                writer = null;
+            }
+        }
+    }
+}

--- a/Demo/AITuber/FileLogger.cs.meta
+++ b/Demo/AITuber/FileLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6da9993ba3234136b66e0cf46791be1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a file logger to the AITuber demo to capture logs of AI speech and comment readings. This feature allows for the preservation of interaction records, which can be useful for accuracy improvements and as source data for long-term memory.

Note: This logger has not been optimized for performance and is recommended for AITuber-specific use only.