### PR TITLE
Improve dialog processing

### DIFF
--- a/Scripts/Dialog/DialogPriorityManager.cs
+++ b/Scripts/Dialog/DialogPriorityManager.cs
@@ -49,16 +49,16 @@ namespace ChatdollKit.Dialog
         {
             if (priority == 0)
             {
-                _ = dialogProcessor.StartDialogAsync(text);
+                _ = dialogProcessor.StartDialogAsync(text + textToAppendNext);
             }
             else
             {
                 dialogQueue.Enqueue(new DialogQueueItem() {
                     Priority = priority, Text = text + textToAppendNext, Payloads = payloads
                 }, priority);
-
-                textToAppendNext = string.Empty;
             }
+
+            textToAppendNext = string.Empty;
         }
 
         public void SetRequestToAppendNext(string text)


### PR DESCRIPTION
- [Make it possible to start another GenAI stream while dialog](https://github.com/uezo/ChatdollKit/commit/66c9e5dae7e1120d7c6bd41bd1aa8cb94c2ec633) 
  - Add `overwrite` argument: If set false, start new dialog (LLM stream) without stopping ongoing dialog.
  - Add OnBeforeProcessContentStreamAsync: Execute before processing content stream.

  By combining these features, you can improve the performance of successive speech by AITuber.

- [Use buffered request regardless of the priority](https://github.com/uezo/ChatdollKit/commit/65ddef13b3d5ccbd0dd318362b8dc1174918314e)