### PR TITLE
Support IsAzure option of ChatGpt LLM by AITuber controller

### DIFF
--- a/Demo/AITuber/AITuberMessageHandler.cs
+++ b/Demo/AITuber/AITuberMessageHandler.cs
@@ -232,6 +232,7 @@ namespace ChatdollKit.Demo
                         if (model != null) chatGPTService.Model = model;
                         if (temperature >= 0) chatGPTService.Temperature = temperature;
                         if (url != null) chatGPTService.ChatCompletionUrl = url;
+                        chatGPTService.IsAzure = message.Payloads.ContainsKey("is_azure") ? Convert.ToBoolean(message.Payloads["is_azure"]) : false;
                     }
                     else if (name == "claude")
                     {


### PR DESCRIPTION
Currently, AITuber controller cannot configure LLM of the Azure OpenAI Service. The ChatGPT LLM Service has an IsAzure option,  This PR can probably configure `IsAzure` option from the Controller using `is_azure` argument.