### PR TITLE
Support dynamic multi language speech synthesizing

### DIFF
--- a/Scripts/LLM/LLMContentProcessor.cs
+++ b/Scripts/LLM/LLMContentProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using UnityEngine;
 using Cysharp.Threading.Tasks;
@@ -38,6 +39,7 @@ namespace ChatdollKit.LLM
             {
                 var splitIndex = 0;
                 var isFirstWord = true;
+                var language = string.Empty;
                 var isInsideThinkTag = false;
                 var thinkStart = $"<{ThinkTag}>";
                 var thinkEnd = $"</{ThinkTag}>";
@@ -113,7 +115,13 @@ namespace ChatdollKit.LLM
                                     continue;
                                 }
 
-                                var contentItem = new LLMContentItem(processedText, isFirstWord);          
+                                var match = Regex.Match(processedText, @"\[lang:([a-zA-Z-]+)\]");
+                                if (match.Success)
+                                {
+                                    language = match.Groups[1].Value;
+                                }
+
+                                var contentItem = new LLMContentItem(processedText, isFirstWord, language);          
                                 HandleSplittedText?.Invoke(contentItem);
                                 if (contentItem != null)
                                 {
@@ -243,12 +251,14 @@ namespace ChatdollKit.LLM
     {
         public string Text { get; set; }
         public bool IsFirstItem { get; set; }
+        public string Language { get; set; }
         public object Data { get; set; }
 
-        public LLMContentItem(string text, bool isFirstItem, object data = null)
+        public LLMContentItem(string text, bool isFirstItem, string language, object data = null)
         {
             Text = text;
             IsFirstItem = isFirstItem;
+            Language = language;
             Data = data;
         }
     }

--- a/Scripts/Model/ModelController.cs
+++ b/Scripts/Model/ModelController.cs
@@ -238,11 +238,15 @@ namespace ChatdollKit.Model
             }
         }
 
-        public AnimatedVoiceRequest ToAnimatedVoiceRequest(string inputText)
+        public AnimatedVoiceRequest ToAnimatedVoiceRequest(string inputText, string language = null)
         {
             var avreq = new AnimatedVoiceRequest();
             var preGap = 0f;
             var ttsConfig = new TTSConfiguration();
+            if (!string.IsNullOrEmpty(language))
+            {
+                ttsConfig.Params["language"] = language;
+            }
 
             var pattern = @"(\[.*?\])|([^[]+)";
             foreach (Match match in Regex.Matches(inputText, pattern))

--- a/Scripts/Model/ModelRequestBroker.cs
+++ b/Scripts/Model/ModelRequestBroker.cs
@@ -78,7 +78,7 @@ namespace ChatdollKit.Model
             }
         }
 
-        private List<AnimatedVoiceRequest> ToAnimatedVoiceRequests(string taggedText)
+        private List<AnimatedVoiceRequest> ToAnimatedVoiceRequests(string taggedText, string language = null)
         {
             var animatedVoiceRequests = new List<AnimatedVoiceRequest>();
             var isFirstAnimatedVoice = true;
@@ -91,7 +91,7 @@ namespace ChatdollKit.Model
                 {
                     if (!string.IsNullOrEmpty(text.Trim()))
                     {
-                        var avreq = modelController.ToAnimatedVoiceRequest(text);
+                        var avreq = modelController.ToAnimatedVoiceRequest(text, language);
                         avreq.StartIdlingOnEnd = isFirstAnimatedVoice;
                         isFirstAnimatedVoice = false;
 

--- a/Scripts/SpeechSynthesizer/AzureSpeechSynthesizer.cs
+++ b/Scripts/SpeechSynthesizer/AzureSpeechSynthesizer.cs
@@ -31,6 +31,7 @@ namespace ChatdollKit.SpeechSynthesizer
         public string Language = "ja-JP";
         public string Gender = "Female";
         public string SpeakerName = "ja-JP-AoiNeural";
+        public Dictionary<string, string> SpeakerMap = new ();
         public AudioType AudioType = AudioType.MPEG;
 
 #if UNITY_WEBGL && !UNITY_EDITOR
@@ -60,7 +61,27 @@ namespace ChatdollKit.SpeechSynthesizer
                 { "Ocp-Apim-Subscription-Key", ApiKey }
             };
 
-            var textML = $"<speak version='1.0' xml:lang='{Language}'><voice xml:lang='{Language}' xml:gender='{Gender}' name='{SpeakerName}'>{text}</voice></speak>";
+            string language;
+            string speaker;
+            if (parameters.ContainsKey("language"))
+            {
+                language = parameters["language"] as string;
+                if (SpeakerMap.ContainsKey(language))
+                {
+                    speaker = SpeakerMap[language];
+                }
+                else
+                {
+                    speaker = SpeakerName;
+                }
+            }
+            else
+            {
+                language = Language;
+                speaker = SpeakerName;
+            }
+
+            var textML = $"<speak version='1.0' xml:lang='{language}'><voice xml:lang='{language}' name='{speaker}'>{text}</voice></speak>";
             var data = System.Text.Encoding.UTF8.GetBytes(textML);
 
             return await DownloadAudioClipAsync(url, data, headers, token);

--- a/Scripts/SpeechSynthesizer/GoogleSpeechSynthesizer.cs
+++ b/Scripts/SpeechSynthesizer/GoogleSpeechSynthesizer.cs
@@ -25,8 +25,8 @@ namespace ChatdollKit.SpeechSynthesizer
 
         public string ApiKey;
         public string Language = "ja-JP";
-        public string Gender = "FEMALE";
         public string SpeakerName = "ja-JP-Standard-A";
+        public Dictionary<string, string> SpeakerMap = new ();
 
         private ChatdollHttp client;
 
@@ -49,7 +49,20 @@ namespace ChatdollKit.SpeechSynthesizer
             {
                 var url = $"https://texttospeech.googleapis.com/v1/text:synthesize?key={ApiKey}";
 
-                var ttsRequest = new GoogleTextToSpeechRequest(text, Language, SpeakerName, Gender, "LINEAR16");
+                string language;
+                string speaker;
+                if (parameters.ContainsKey("language"))
+                {
+                    language = parameters["language"] as string;
+                    speaker = SpeakerMap[language];
+                }
+                else
+                {
+                    language = Language;
+                    speaker = SpeakerName;
+                }
+
+                var ttsRequest = new GoogleTextToSpeechRequest(text, language, speaker, "LINEAR16");
                 var ttsResponse = await client.PostJsonAsync<GoogleTextToSpeechResponse>(url, ttsRequest, cancellationToken: token);
 
                 if (!string.IsNullOrEmpty(ttsResponse.audioContent))
@@ -74,7 +87,6 @@ namespace ChatdollKit.SpeechSynthesizer
         {
             public string languageCode;
             public string name;
-            public string ssmlGender;
         }
 
         class GoogleTextToSpeechAudioConfig
@@ -88,10 +100,10 @@ namespace ChatdollKit.SpeechSynthesizer
             public GoogleTextToSpeechVoice voice;
             public GoogleTextToSpeechAudioConfig audioConfig;
 
-            public GoogleTextToSpeechRequest(string text, string language, string speakerName, string speakerGender, string audioEncoding)
+            public GoogleTextToSpeechRequest(string text, string language, string speakerName, string audioEncoding)
             {
                 input = new GoogleTextToSpeechInput() { text = text };
-                voice = new GoogleTextToSpeechVoice() { languageCode = language, name = speakerName, ssmlGender = speakerGender };
+                voice = new GoogleTextToSpeechVoice() { languageCode = language, name = speakerName };
                 audioConfig = new GoogleTextToSpeechAudioConfig() { audioEncoding = audioEncoding };
             }
         }

--- a/Scripts/SpeechSynthesizer/SpeechSynthesizerBase.cs
+++ b/Scripts/SpeechSynthesizer/SpeechSynthesizerBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using UnityEngine;
 using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace ChatdollKit.SpeechSynthesizer
 {
@@ -17,16 +18,20 @@ namespace ChatdollKit.SpeechSynthesizer
         [SerializeField]
         protected bool isDebug;
 
-        public async UniTask<AudioClip> GetAudioClipAsync(string text, Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
+        protected virtual string GetCacheKey(string text, Dictionary<string, object> parameters)
+        {
+            return $"{text}_{JsonConvert.SerializeObject(parameters)}".GetHashCode().ToString();
+        }
+
+        public async UniTask<AudioClip> GetAudioClipAsync(string text, Dictionary<string, object> parameters, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(text.Trim()))
             {
                 return null;
             }
 
-            // Make cache key
-            var cacheKey = parameters.ContainsKey("style") && !string.IsNullOrEmpty((string)parameters["style"])
-                ? $"[{parameters["style"]}]{text}" : text;
+            // Get cache key
+            var cacheKey = GetCacheKey(text, parameters);
 
             // Return cache if exists
             if (HasCache(cacheKey))


### PR DESCRIPTION
Implemented language tagging in responses to allow explicit language specification for the SpeechSynthesizer component, ensuring proper voice synthesis when supported.

```md
## About Language

You can speak various languages.
When responding in a language other than Japanese, always prepend a language tag such as [lang:en-US] or [lang:zh-CN] at the beginning of the response.
Similarly, when switching back to Japanese from another language, always prepend [lang:ja-JP] at the beginning of the response.
```

This enhancement improves the multilingual voice interaction capabilities by dynamically specifying the target language for speech synthesis.