### PR TITLE
Add ContextId for conversation-level identification

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -133,6 +133,7 @@ namespace ChatdollKit.LLM.ChatGPT
             // Start streaming session
             var chatGPTSession = new ChatGPTSession();
             chatGPTSession.Contexts = messages;
+            chatGPTSession.ContextId = contextId;
             chatGPTSession.StreamingTask = StartStreamingAsync(chatGPTSession, customParameters, customHeaders, useFunctions, token);
             await WaitForFunctionInfo(chatGPTSession, token);
 

--- a/Scripts/LLM/Claude/ClaudeService.cs
+++ b/Scripts/LLM/Claude/ClaudeService.cs
@@ -106,6 +106,7 @@ namespace ChatdollKit.LLM.Claude
             // Start streaming session
             var claudeSession = new ClaudeSession();
             claudeSession.Contexts = messages;
+            claudeSession.ContextId = contextId;
             claudeSession.StreamingTask = StartStreamingAsync(claudeSession, customParameters, customHeaders, useFunctions, token);
             await WaitForResponseType(claudeSession, token);
 

--- a/Scripts/LLM/CommandR/CommandRService.cs
+++ b/Scripts/LLM/CommandR/CommandRService.cs
@@ -103,6 +103,7 @@ namespace ChatdollKit.LLM.CommandR
             // Start streaming session
             var commandRSession = new CommandRSession();
             commandRSession.Contexts = messages;
+            commandRSession.ContextId = contextId;
             commandRSession.StreamingTask = StartStreamingAsync(inputText, toolResults, commandRSession, customParameters, customHeaders, useFunctions, token);
             await WaitForResponseType(commandRSession, token);
 

--- a/Scripts/LLM/Dify/DifyService.cs
+++ b/Scripts/LLM/Dify/DifyService.cs
@@ -91,6 +91,9 @@ namespace ChatdollKit.LLM.Dify
                 difySession.ConversationId = GetConversationId();
             }
 
+            // Use ConversationId as ContextId, not base.contextId
+            difySession.ContextId = difySession.ConversationId;
+
             difySession.StreamingTask = StartStreamingAsync(difySession, customParameters, customHeaders, useFunctions, token);
 
             // Retry

--- a/Scripts/LLM/Gemini/GeminiService.cs
+++ b/Scripts/LLM/Gemini/GeminiService.cs
@@ -55,6 +55,10 @@ namespace ChatdollKit.LLM.Gemini
                 index--;
             }
 
+            if (string.IsNullOrEmpty(contextId))
+            {
+                contextId = Guid.NewGuid().ToString();
+            }
             return histories;
         }
 
@@ -127,6 +131,7 @@ namespace ChatdollKit.LLM.Gemini
             // Start streaming session
             var geminiSession = new GeminiSession();
             geminiSession.Contexts = messages;
+            geminiSession.ContextId = contextId;
             geminiSession.StreamingTask = StartStreamingAsync(geminiSession, customParameters, customHeaders, useFunctions, token);
             await WaitForResponseType(geminiSession, token);
 

--- a/Scripts/LLM/ILLMService.cs
+++ b/Scripts/LLM/ILLMService.cs
@@ -15,7 +15,7 @@ namespace ChatdollKit.LLM
         UniTask<List<ILLMMessage>> MakePromptAsync(string userId, string inputText, Dictionary<string, object> payloads, CancellationToken token = default);
         UniTask<ILLMSession> GenerateContentAsync(List<ILLMMessage> messages, Dictionary<string, object> payloads = null, bool useFunctions = true, int retryCounter = 1, CancellationToken token = default);
         ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null);
-        Func<ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
+        Func<string, Dictionary<string, object>, ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
         Action <Dictionary<string, string>, ILLMSession> HandleExtractedTags { get; set; }
         Func<string, UniTask<byte[]>> CaptureImage { get; set; }
     }
@@ -33,9 +33,9 @@ namespace ChatdollKit.LLM
         bool IsVisionAvailable { get; set; }
         ResponseType ResponseType { get; set; }
         UniTask StreamingTask { get; set; }
-        Func<UniTask> OnStreamingEnd { get; set; }
         string FunctionName { get; set; }
         List<ILLMMessage> Contexts { get; set; }
+        string ContextId { get; set; }
     }
 
     public interface ILLMMessage { }

--- a/Scripts/LLM/LLMServiceBase.cs
+++ b/Scripts/LLM/LLMServiceBase.cs
@@ -45,11 +45,12 @@ namespace ChatdollKit.LLM
         protected int contextTimeout = 600;    // 10 min
         protected float contextUpdatedAt;
         protected List<ILLMMessage> context = new List<ILLMMessage>();
+        protected string contextId = string.Empty;
 
         public Action OnEnabled { get; set; }
         public Action <Dictionary<string, string>, ILLMSession> HandleExtractedTags { get; set; }
         public Func<string, UniTask<byte[]>> CaptureImage { get; set; }
-        public Func<ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
+        public Func<string, Dictionary<string, object>, ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
         public List<ILLMTool> Tools { get; set; } = new List<ILLMTool>();
 
         public virtual List<ILLMMessage> GetContext(int count)
@@ -60,6 +61,10 @@ namespace ChatdollKit.LLM
             }
 
             // Return copy not to update context directly
+            if (string.IsNullOrEmpty(contextId))
+            {
+                contextId = Guid.NewGuid().ToString();
+            }
             return context.Skip(context.Count - count).ToList();
         }
 
@@ -76,6 +81,7 @@ namespace ChatdollKit.LLM
         public virtual void ClearContext()
         {
             context.Clear();
+            contextId = string.Empty;
             contextUpdatedAt = Time.time;
         }
 
@@ -124,9 +130,9 @@ namespace ChatdollKit.LLM
         public bool IsVisionAvailable { get; set; } = true;
         public ResponseType ResponseType { get; set; } = ResponseType.None;
         public UniTask StreamingTask { get; set; }
-        public Func<UniTask> OnStreamingEnd { get; set; }   // No longer used in v0.8.4
         public string FunctionName { get; set; }
         public List<ILLMMessage> Contexts { get; set; }
+        public string ContextId { get; set; }
 
         public LLMSession()
         {
@@ -135,6 +141,7 @@ namespace ChatdollKit.LLM
             CurrentStreamBuffer = string.Empty;
             ResponseType = ResponseType.None;
             Contexts = new List<ILLMMessage>();
+            ContextId = string.Empty;
         }
     }
 


### PR DESCRIPTION
- Introduced ContextId to uniquely identify each conversation session.
- This enables better tracking and referencing of individual chat sessions.