### PR TITLE
Add support for Long-Term Memory

### DIFF
--- a/Demo/Scripts/Main08.cs
+++ b/Demo/Scripts/Main08.cs
@@ -81,46 +81,15 @@ namespace ChatdollKit.Demo
             faceOnStart.Add(new FaceExpression("Joy", 3.0f));
             modelController.SetFace(faceOnStart);
 
-            // User defined tag example: Dynamic multi language switching
-            // Insert following instruction to ChatGPTService.
-            // ----
-            // If you want change current language, insert language tag like [language:en-US].
-            //
-            // Example:
-            // [language:en-US]From now on, let's talk in English.
-            // ----
-            // var contentProcessor = gameObject.GetComponent<LLMContentProcessor>();
-            // contentProcessor.HandleSplittedText += (contentItem) =>
+            // // Long-Term Memory Manager (e.g. ChatMemory https://github.com/uezo/chatmemory)
+            // // 1. Add ChatMemoryIntegrator to this game object
+            // // 2. Configure ChatMemory url and user id
+            // // 3. To retrieve memory in the conversation add ChatMemoryTool to this game object
+            // var chatMemory = gameObject.GetComponent<ChatMemoryIntegrator>();
+            // dialogProcessor.LLMServiceExtensions.OnStreamingEnd += async (text, payloads, llmSession, token) =>
             // {
-            //     if (contentItem.Text.StartsWith("[language:"))
-            //     {
-            //         var languageCode = string.Empty;
-            //         var match = Regex.Match(contentItem.Text, @"\[language:(.*?)\]");
-            //         if (match.Success)
-            //         {
-            //             languageCode = match.Groups[1].Value;
-            //             // OpenAI TTS requires ISO-639-1 format
-            //             languageCode = languageCode.Contains("-") ? languageCode.Split('-')[0] : languageCode;
-            //         }
-
-            //         // Apply language to SpeechSynthesizer
-            //         if (languageCode != "ja" && !string.IsNullOrEmpty(languageCode))
-            //         {
-            //             var openAISpeechSynthesizer = gameObject.GetComponent<OpenAISpeechSynthesizer>();
-            //             modelController.SpeechSynthesizerFunc = openAISpeechSynthesizer.GetAudioClipAsync;
-            //         }
-            //         else
-            //         {
-            //             var voicevoxSpeechSynthesizer = gameObject.GetComponent<VoicevoxSpeechSynthesizer>();
-            //             modelController.SpeechSynthesizerFunc = voicevoxSpeechSynthesizer.GetAudioClipAsync;
-            //         }
-
-            //         // Apply language to SpeechListener
-            //         var openAIListener = gameObject.GetComponent<OpenAISpeechListener>();
-            //         openAIListener.Language = languageCode;
-
-            //         Debug.Log($"Set language to {languageCode}");
-            //     }
+            //     // Add history to ChatMemory service
+            //     chatMemory.AddHistory(llmSession.ContextId, text, llmSession.CurrentStreamBuffer, token).Forget();
             // };
         }
 

--- a/Extension/ChatMemory.meta
+++ b/Extension/ChatMemory.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 689278deef1874d8797cbace4a99e818
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Extension/ChatMemory/ChatMemoryIntegrator.cs
+++ b/Extension/ChatMemory/ChatMemoryIntegrator.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using Cysharp.Threading.Tasks;
+using ChatdollKit.Network;
+using System;
+
+namespace ChatdollKit.Extension.ChatMemory
+{
+    public class ChatMemoryIntegrator : MonoBehaviour
+    {
+        [SerializeField]
+        private string BaseUrl;
+        public string UserId;
+        [SerializeField]
+        private bool isDebug;
+        private ChatdollHttp httpClient = new ChatdollHttp(timeout: 10000);
+
+        public async UniTask AddHistory(string sessionId, string requestText, string responseText, CancellationToken token = default)
+        {
+            if (string.IsNullOrEmpty(UserId))
+            {
+                Debug.LogWarning("UserId is required to add history to ChatMemory service.");
+                return;
+            }
+
+            if (isDebug)
+            {
+                Debug.Log($"AddHistory: user={UserId}, sessionId={sessionId}, request='{requestText}', response='{responseText}'");
+            }
+
+            try
+            {
+                await httpClient.PostJsonAsync(
+                    $"{BaseUrl}/history",
+                    data: new Dictionary<string, object>()
+                    {
+                        { "user_id", UserId },
+                        { "session_id", sessionId },
+                        { "messages", new List<Dictionary<string, string>>() {
+                            new() { { "role", "user" }, { "content", requestText } },
+                            new() { { "role", "assistant" }, { "content", responseText } }
+                        }},
+                    },
+                    cancellationToken: token
+                );
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Error at adding history to ChatMemory: {ex.Message}\n{ex.StackTrace}");
+            }
+        }
+
+        public async UniTask<SearchResponse> SearchMemory(string query, int top_k = 5, bool search_content = false, bool include_retrieved_data = false, CancellationToken token = default)
+        {
+            if (string.IsNullOrEmpty(UserId))
+            {
+                Debug.LogWarning("UserId is required to search memory at ChatMemory service.");
+                return new SearchResponse();
+            }
+
+            if (isDebug)
+            {
+                Debug.Log($"SearchMemory (Request): user={UserId}, query='{query}'");
+            }
+
+            var response = await httpClient.PostJsonAsync<SearchResponse>(
+                $"{BaseUrl}/search",
+                data: new Dictionary<string, object>()
+                {
+                    { "user_id", UserId },
+                    { "query", query },
+                    { "top_k", top_k },
+                    { "search_content", search_content },
+                    { "include_retrieved_data", include_retrieved_data }
+                },
+                cancellationToken: token
+            );
+
+            if (isDebug)
+            {
+                if (response.result != null)
+                {
+                    Debug.Log($"SearchMemory (Response): answer={response.result.answer}, retrieved_data='{response.result.retrieved_data}'");
+                }
+                else
+                {
+                    Debug.Log("SearchMemory (Response): No result");
+                }
+            }
+
+            return response;
+        }
+    }
+
+    public class SearchResponse
+    {
+        public SearchResult result { get; set; }
+    }
+
+    public class SearchResult
+    {
+        public string answer { get; set; }
+        public string retrieved_data { get; set; }
+    }
+}

--- a/Extension/ChatMemory/ChatMemoryIntegrator.cs.meta
+++ b/Extension/ChatMemory/ChatMemoryIntegrator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f9544326880404c2f8b5733bb6a7caa3

--- a/Extension/ChatMemory/ChatMemoryTool.cs
+++ b/Extension/ChatMemory/ChatMemoryTool.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using Newtonsoft.Json;
+using ChatdollKit.LLM;
+
+namespace ChatdollKit.Extension.ChatMemory
+{
+    public class ChatMemoryTool : ToolBase
+    {
+        public bool IncludeRetrivedData;
+        private ChatMemoryIntegrator chatMemoryIntegrator;
+
+        public string FunctionName = "search_memory";
+        public string FunctionDescription = "Search and retrieve long-term memory.";
+
+        private void Start()
+        {
+            chatMemoryIntegrator = gameObject.GetComponent<ChatMemoryIntegrator>();
+        }
+
+        public override ILLMTool GetToolSpec()
+        {
+            // Make function spec for Function Calling
+            var func = new LLMTool(FunctionName, FunctionDescription);
+            func.AddProperty("query", new Dictionary<string, object>() { { "type", "string" } });
+            return func;
+        }
+
+        protected override async UniTask<ToolResponse> ExecuteFunction(string argumentsJsonString, CancellationToken token)
+        {
+            var arguments = JsonConvert.DeserializeObject<Dictionary<string, string>>(argumentsJsonString);
+            var searchResponse = await chatMemoryIntegrator.SearchMemory(arguments["query"], include_retrieved_data: IncludeRetrivedData);
+            return new ToolResponse(JsonConvert.SerializeObject(searchResponse.result));
+        }
+    }
+}

--- a/Extension/ChatMemory/ChatMemoryTool.cs.meta
+++ b/Extension/ChatMemory/ChatMemoryTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d2cd53afce2644b9bf15a5ca5701807
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ To run the demo for version 0.8, please follow the steps below after importing t
   - [User Defined Tag](#user-defined-tag)
   - [Multi Modal](#multi-modal)
   - [Chain of Thought Prompting](#chain-of-thought-prompting)
+  - [Long-Term Memory](#long-term-memory)
 - [🗣️ Speech Synthesizer (Text-to-Speech)](#%EF%B8%8F-speech-synthesizer-text-to-speech)
   - [Voice Prefetch Mode](#voice-prefetch-mode)
   - [Make custom SpeechSynthesizer](#make-custom-speechsynthesizer)
@@ -417,6 +418,32 @@ Chain of Thought (CoT) prompting is a technique to enhance AI performance. For m
 ChatdollKit supports Chain of Thought by excluding sentences wrapped in `<thinking> ~ </thinking>` tags from speech synthesis.
 
 You can customize the tag by setting a preferred word (e.g., "reason") as the `ThinkTag` in the inspector of `LLMContentProcessor`.
+
+
+### Long-Term Memory
+
+ChatdollKit itself does not have a built-in mechanism for managing long-term memory. However, by implementing `OnStreamingEnd`, it is possible to accumulate memory. Additionally, by using a tool that retrieves stored memories, the system can recall and reflect them in conversations.
+
+The following is an example using [ChatMemory](https://github.com/uezo/chatmemory).
+
+First, to store memories, attach the `Extension/ChatMemory/ChatMemoryIntegrator` component to the main GameObject and set the ChatMemory service URL and a user ID. The user ID can be any value, but if you are building a service for multiple users, make sure to assign an ID that can uniquely identify each user within your service from code-behind.
+
+Next, add the following code to an appropriate location (such as `Main`) so that the request and response messages are stored in ChatMemory as history when the LLM stream finishes.
+
+```csharp
+using ChatdollKit.Extension.ChatMemory;
+
+var chatMemory = gameObject.GetComponent<ChatMemoryIntegrator>();
+dialogProcessor.LLMServiceExtensions.OnStreamingEnd += async (text, payloads, llmSession, token) =>
+{
+    await chatMemory.AddHistory(llmSession.ContextId, text, llmSession.CurrentStreamBuffer, token);
+};
+```
+
+
+To retrieve memories and include them in the conversation, simply add the `Extension/ChatMemory/ChatMemoryTool` component to the main GameObject.
+
+**NOTE:** ChatMemory manages what is known as episodic memory. There is also an entity called `Knowledge`, which is known as corresponds to factual information, but it is not automatically extracted or stored. Handle it manually as needed. (By default, it is included in search targets.)
 
 
 ## 🗣️ Speech Synthesizer (Text-to-Speech)


### PR DESCRIPTION
ChatdollKit itself does not have a built-in mechanism for managing long-term memory. However, by implementing `OnStreamingEnd`, it is possible to accumulate memory. Additionally, by using a tool that retrieves stored memories, the system can recall and reflect them in conversations.

See README to know the details.