### PR TITLE
Add OpenAI compatible API option to ChatGPTService

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -16,6 +16,7 @@ namespace ChatdollKit.LLM.ChatGPT
         public string Model = "gpt-4o-mini";
         public string ChatCompletionUrl;
         public bool IsAzure;
+        public bool IsOpenAICompatibleAPI;
         public int MaxTokens = 0;
         public float Temperature = 0.5f;
         public float FrequencyPenalty = 0.0f;
@@ -166,11 +167,14 @@ namespace ChatdollKit.LLM.ChatGPT
                 { "model", Model },
                 { "temperature", Temperature },
                 { "messages", chatGPTSession.Contexts },
-                { "frequency_penalty", FrequencyPenalty },
-                { "presence_penalty", PresencePenalty },
                 { "stream", true },
             };
 
+            if (!IsOpenAICompatibleAPI)
+            {
+                data["frequency_penalty"] = FrequencyPenalty;
+                data["presence_penalty"] = PresencePenalty;
+            }
             if (MaxTokens > 0)
             {
                 data.Add("max_tokens", MaxTokens);

--- a/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
@@ -46,10 +46,14 @@ namespace ChatdollKit.LLM.ChatGPT
                 { "model", Model },
                 { "temperature", Temperature },
                 { "messages", chatGPTSession.Contexts },
-                { "frequency_penalty", FrequencyPenalty },
-                { "presence_penalty", PresencePenalty },
                 { "stream", true },
             };
+
+            if (!IsOpenAICompatibleAPI)
+            {
+                data["frequency_penalty"] = FrequencyPenalty;
+                data["presence_penalty"] = PresencePenalty;
+            }
             if (MaxTokens > 0)
             {
                 data.Add("max_tokens", MaxTokens);


### PR DESCRIPTION
Introduces the IsOpenAICompatibleAPI flag to both ChatGPTService and ChatGPTServiceWebGL. `frequency_penalty` and `presence_penalty` parameters are now conditionally included based on this flag, improving compatibility with OpenAI-compatible APIs. (e.g. Gemini, Grok)