### PR TITLE
Fix bug where WebGL build fails

### DIFF
--- a/Scripts/LLM/AIAvatarKit/AIAvatarKitServiceWebGL.cs
+++ b/Scripts/LLM/AIAvatarKit/AIAvatarKitServiceWebGL.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using UnityEngine;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Cysharp.Threading.Tasks;
 
 namespace ChatdollKit.LLM.AIAvatarKit


### PR DESCRIPTION
Add missing using `Newtonsoft.Json.Linq` in AIAvatarKitServiceWebGL.🙇‍♀️