### PR TITLE
Add native microphone support for Android, iOS, and macOSX

### DIFF
--- a/Scripts/IO/AndroidNativeMicrophone.cs
+++ b/Scripts/IO/AndroidNativeMicrophone.cs
@@ -1,0 +1,360 @@
+#if UNITY_ANDROID
+
+using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace ChatdollKit.IO
+{
+    public static class AndroidNativeMicrophone
+    {
+        private const string PLUGIN_NAME = "androidnativemicrophone";
+
+        [DllImport(PLUGIN_NAME)]
+        private static extern int AndroidNativeMicrophonePlugin_GetDeviceCount();
+        [DllImport(PLUGIN_NAME)]
+        private static extern IntPtr AndroidNativeMicrophonePlugin_GetDeviceName(int index);
+        [DllImport(PLUGIN_NAME)]
+        private static extern int AndroidNativeMicrophonePlugin_Start(string deviceName, int lengthSec, int frequency);
+        [DllImport(PLUGIN_NAME)]
+        private static extern int AndroidNativeMicrophonePlugin_StartWithVoiceProcessing(string deviceName, int lengthSec, int frequency, int enableVoiceProcessing);
+        [DllImport(PLUGIN_NAME)]
+        private static extern void AndroidNativeMicrophonePlugin_End();
+        [DllImport(PLUGIN_NAME)]
+        private static extern int AndroidNativeMicrophonePlugin_IsRecording();
+        [DllImport(PLUGIN_NAME)]
+        private static extern int AndroidNativeMicrophonePlugin_GetPosition();
+        [DllImport(PLUGIN_NAME)]
+        private static extern IntPtr AndroidNativeMicrophonePlugin_GetAudioData();
+        [DllImport(PLUGIN_NAME)]
+        private static extern void AndroidNativeMicrophonePlugin_ForceReset();
+
+        private static AudioClip currentClip;
+        private static bool isCurrentlyRecording = false;
+        private static string currentDevice = null;
+        private static float[] pluginAudioBuffer;
+        private static int bufferSize;
+        private static int sampleRate;
+        private static bool voiceProcessingEnabled = false;
+
+        // Enable/disable debug logging
+        private const bool DEBUG_LOG_ENABLED = true;
+
+        private static void DebugLog(string message)
+        {
+            if (DEBUG_LOG_ENABLED)
+            {
+                Debug.Log($"[AndroidNativeMicrophone] {message}");
+            }
+        }
+
+        private static void DebugLogError(string message)
+        {
+            Debug.LogError($"[AndroidNativeMicrophone] {message}");
+        }
+
+        /// <summary>
+        /// Get all available audio input devices
+        /// </summary>
+        public static string[] devices
+        {
+            get
+            {
+#if !UNITY_EDITOR
+                    int count = AndroidNativeMicrophonePlugin_GetDeviceCount();
+                    string[] deviceNames = new string[count];
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        IntPtr namePtr = AndroidNativeMicrophonePlugin_GetDeviceName(i);
+                        deviceNames[i] = Marshal.PtrToStringAnsi(namePtr);
+                    }
+
+                    return deviceNames;
+#else
+                // Return Unity's default devices when not on Android
+                return Microphone.devices;
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Start recording with default voice processing enabled (echo cancellation ON)
+        /// </summary>
+        public static AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency)
+        {
+            return Start(deviceName, loop, lengthSec, frequency, true);
+        }
+
+        /// <summary>
+        /// Start recording with optional voice processing
+        /// </summary>
+        /// <param name="deviceName">Device name or null for default</param>
+        /// <param name="loop">Loop recording (not used in current implementation)</param>
+        /// <param name="lengthSec">Recording buffer length in seconds</param>
+        /// <param name="frequency">Sample rate in Hz (16000 or 48000 recommended)</param>
+        /// <param name="enableVoiceProcessing">Enable Android voice processing (echo cancellation, noise reduction, AGC)</param>
+        public static AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency, bool enableVoiceProcessing)
+        {
+#if !UNITY_EDITOR
+                // Force cleanup if already recording
+                if (isCurrentlyRecording)
+                {
+                    ForceReset();
+                }
+
+                string targetDevice = string.IsNullOrEmpty(deviceName) ? "Default" : deviceName;
+
+                DebugLog($"Starting recording: device={targetDevice}, length={lengthSec}s, freq={frequency}Hz, voiceProcessing={enableVoiceProcessing}");
+
+                // Call appropriate native function based on voice processing setting
+                int result = enableVoiceProcessing
+                    ? AndroidNativeMicrophonePlugin_StartWithVoiceProcessing(targetDevice, lengthSec, frequency, 1)
+                    : AndroidNativeMicrophonePlugin_Start(targetDevice, lengthSec, frequency);
+
+                if (result == 1)
+                {
+                    // Create Unity AudioClip as container
+                    currentClip = AudioClip.Create("MicrophoneClip", lengthSec * frequency, 1, frequency, false);
+                    
+                    // IMPORTANT: Set HideFlags to prevent serialization issues in Editor
+                    currentClip.hideFlags = HideFlags.DontSave;
+                    
+                    isCurrentlyRecording = true;
+                    currentDevice = targetDevice;
+                    bufferSize = lengthSec * frequency;
+                    sampleRate = frequency;
+                    voiceProcessingEnabled = enableVoiceProcessing;
+
+                    // Allocate managed buffer for audio data transfer
+                    pluginAudioBuffer = new float[bufferSize];
+
+                    DebugLog($"Recording started successfully. BufferSize: {bufferSize}, VoiceProcessing: {enableVoiceProcessing}");
+                    return currentClip;
+                }
+                else
+                {
+                    DebugLogError($"Failed to start recording. Result: {result}");
+                    return null;
+                }
+#else
+            // Fallback to Unity's Microphone on non-Android platforms
+            DebugLog("Using Unity's built-in Microphone (not on Android device)");
+            return Microphone.Start(deviceName, loop, lengthSec, frequency);
+#endif
+        }
+
+        /// <summary>
+        /// Stop recording on specified device
+        /// </summary>
+        public static void End(string deviceName)
+        {
+#if !UNITY_EDITOR
+                if (!isCurrentlyRecording)
+                    return;
+
+                // Check if we're ending the correct device
+                if (!string.IsNullOrEmpty(deviceName) && deviceName != currentDevice)
+                    return;
+
+                DebugLog("Ending recording");
+                AndroidNativeMicrophonePlugin_End();
+
+                // Properly destroy AudioClip
+                if (currentClip != null)
+                {
+                    UnityEngine.Object.Destroy(currentClip);
+                    currentClip = null;
+                }
+
+                // Clear state
+                isCurrentlyRecording = false;
+                currentDevice = null;
+                pluginAudioBuffer = null;
+                voiceProcessingEnabled = false;
+#else
+            // Fallback to Unity's Microphone
+            Microphone.End(deviceName);
+#endif
+        }
+
+        /// <summary>
+        /// Check if currently recording on specified device
+        /// </summary>
+        public static bool IsRecording(string deviceName)
+        {
+#if !UNITY_EDITOR
+                if (!isCurrentlyRecording)
+                    return false;
+
+                // Check device match
+                if (!string.IsNullOrEmpty(deviceName) && deviceName != currentDevice)
+                    return false;
+
+                // Verify with native plugin
+                bool pluginIsRecording = AndroidNativeMicrophonePlugin_IsRecording() == 1;
+
+                if (!pluginIsRecording)
+                {
+                    isCurrentlyRecording = false;
+                    return false;
+                }
+
+                // Update AudioClip with latest data
+                UpdateAudioClip();
+                return true;
+#else
+            // Fallback to Unity's Microphone
+            return Microphone.IsRecording(deviceName);
+#endif
+        }
+
+        /// <summary>
+        /// Get current recording position in samples
+        /// </summary>
+        public static int GetPosition(string deviceName)
+        {
+#if !UNITY_EDITOR
+                if (!IsRecording(deviceName))
+                    return 0;
+
+                return AndroidNativeMicrophonePlugin_GetPosition();
+#else
+            // Fallback to Unity's Microphone
+            return Microphone.GetPosition(deviceName);
+#endif
+        }
+
+        /// <summary>
+        /// Transfer audio data from native plugin to Unity AudioClip
+        /// </summary>
+        private static void UpdateAudioClip()
+        {
+#if !UNITY_EDITOR
+                if (currentClip == null || pluginAudioBuffer == null)
+                    return;
+
+                IntPtr dataPtr = AndroidNativeMicrophonePlugin_GetAudioData();
+                if (dataPtr == IntPtr.Zero)
+                    return;
+
+                try
+                {
+                    // Copy native audio buffer to managed array
+                    Marshal.Copy(dataPtr, pluginAudioBuffer, 0, bufferSize);
+
+                    // Update AudioClip with new data
+                    currentClip.SetData(pluginAudioBuffer, 0);
+                }
+                catch (Exception ex)
+                {
+                    DebugLogError($"Error updating AudioClip: {ex.Message}");
+                }
+#endif
+        }
+
+        /// <summary>
+        /// Force reset all recording state
+        /// </summary>
+        public static void ForceReset()
+        {
+#if !UNITY_EDITOR
+                DebugLog("Force resetting plugin state");
+
+                try
+                {
+                    // Reset native plugin
+                    AndroidNativeMicrophonePlugin_ForceReset();
+
+                    // Properly destroy AudioClip if it exists
+                    if (currentClip != null)
+                    {
+                        UnityEngine.Object.Destroy(currentClip);
+                        currentClip = null;
+                    }
+
+                    // Clear managed state
+                    isCurrentlyRecording = false;
+                    currentDevice = null;
+                    pluginAudioBuffer = null;
+                    voiceProcessingEnabled = false;
+
+                    DebugLog("Plugin and Unity state reset successfully");
+                }
+                catch (Exception ex)
+                {
+                    DebugLogError($"Error during force reset: {ex.Message}");
+                }
+#endif
+        }
+
+        /// <summary>
+        /// Check if voice processing (echo cancellation) is currently enabled
+        /// </summary>
+        public static bool IsVoiceProcessingEnabled()
+        {
+            return voiceProcessingEnabled;
+        }
+
+        /// <summary>
+        /// Request microphone permission (Android 6.0+)
+        /// </summary>
+        public static void RequestMicrophonePermission()
+        {
+#if !UNITY_EDITOR
+                DebugLog("Requesting microphone permission for Android");
+                
+                if (!UnityEngine.Android.Permission.HasUserAuthorizedPermission(UnityEngine.Android.Permission.Microphone))
+                {
+                    UnityEngine.Android.Permission.RequestUserPermission(UnityEngine.Android.Permission.Microphone);
+                }
+                else
+                {
+                    DebugLog("Microphone permission already granted");
+                }
+#else
+            DebugLog("RequestMicrophonePermission is Android specific");
+#endif
+        }
+
+        /// <summary>
+        /// Check if microphone permission is granted
+        /// </summary>
+        public static bool HasMicrophonePermission()
+        {
+#if !UNITY_EDITOR
+                return UnityEngine.Android.Permission.HasUserAuthorizedPermission(UnityEngine.Android.Permission.Microphone);
+#else
+            return true; // Assume permission on non-Android platforms
+#endif
+        }
+
+#if UNITY_EDITOR
+        // Unity Editor cleanup handling
+        [UnityEditor.InitializeOnLoadMethod]
+        private static void InitializeOnLoad()
+        {
+            UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(UnityEditor.PlayModeStateChange state)
+        {
+            // Clean up when exiting play mode or edit mode
+            if (state == UnityEditor.PlayModeStateChange.ExitingPlayMode ||
+                state == UnityEditor.PlayModeStateChange.ExitingEditMode)
+            {
+                try
+                {
+                    ForceReset();
+                }
+                catch (Exception ex)
+                {
+                    // Use warning instead of error for editor cleanup
+                    Debug.LogWarning($"[AndroidNativeMicrophone] Cleanup warning: {ex.Message}");
+                }
+            }
+        }
+#endif
+    }
+}
+#endif

--- a/Scripts/IO/AndroidNativeMicrophone.cs.meta
+++ b/Scripts/IO/AndroidNativeMicrophone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 861795b0f620c4136bef6af81e7dde92

--- a/Scripts/IO/IOSNativeMicrophone.cs
+++ b/Scripts/IO/IOSNativeMicrophone.cs
@@ -1,0 +1,355 @@
+#if UNITY_IOS
+
+using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace ChatdollKit.IO
+{
+    public static class IOSNativeMicrophone
+    {
+        [DllImport("__Internal")]
+        private static extern int iOSNativeMicrophonePlugin_GetDeviceCount();
+        [DllImport("__Internal")]
+        private static extern IntPtr iOSNativeMicrophonePlugin_GetDeviceName(int index);
+        [DllImport("__Internal")]
+        private static extern int iOSNativeMicrophonePlugin_Start(string deviceName, int lengthSec, int frequency);
+        [DllImport("__Internal")]
+        private static extern int iOSNativeMicrophonePlugin_StartWithVoiceProcessing(string deviceName, int lengthSec, int frequency, int enableVoiceProcessing);
+        [DllImport("__Internal")]
+        private static extern void iOSNativeMicrophonePlugin_End();
+        [DllImport("__Internal")]
+        private static extern int iOSNativeMicrophonePlugin_IsRecording();
+        [DllImport("__Internal")]
+        private static extern int iOSNativeMicrophonePlugin_GetPosition();
+        [DllImport("__Internal")]
+        private static extern IntPtr iOSNativeMicrophonePlugin_GetAudioData();
+        [DllImport("__Internal")]
+        private static extern void iOSNativeMicrophonePlugin_ForceReset();
+
+        private static AudioClip currentClip;
+        private static bool isCurrentlyRecording = false;
+        private static string currentDevice = null;
+        private static float[] pluginAudioBuffer;
+        private static int bufferSize;
+        private static int sampleRate;
+        private static bool voiceProcessingEnabled = false;
+
+        // Enable/disable debug logging
+        private const bool DEBUG_LOG_ENABLED = true;
+
+        private static void DebugLog(string message)
+        {
+            if (DEBUG_LOG_ENABLED)
+            {
+                Debug.Log($"[iOSNativeMicrophone] {message}");
+            }
+        }
+
+        private static void DebugLogError(string message)
+        {
+            Debug.LogError($"[iOSNativeMicrophone] {message}");
+        }
+
+        /// <summary>
+        /// Get all available audio input devices
+        /// </summary>
+        public static string[] devices
+        {
+            get
+            {
+#if !UNITY_EDITOR
+                int count = iOSNativeMicrophonePlugin_GetDeviceCount();
+                string[] deviceNames = new string[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    IntPtr namePtr = iOSNativeMicrophonePlugin_GetDeviceName(i);
+                    deviceNames[i] = Marshal.PtrToStringAnsi(namePtr);
+                }
+
+                return deviceNames;
+#else
+                // Return Unity's default devices when not on iOS
+                return Microphone.devices;
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Start recording with default voice processing enabled
+        /// </summary>
+        public static AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency)
+        {
+            return Start(deviceName, loop, lengthSec, frequency, true);
+        }
+
+        /// <summary>
+        /// Start recording with optional voice processing
+        /// </summary>
+        /// <param name="deviceName">Device name or null for default</param>
+        /// <param name="loop">Loop recording (not used in current implementation)</param>
+        /// <param name="lengthSec">Recording buffer length in seconds</param>
+        /// <param name="frequency">Sample rate in Hz</param>
+        /// <param name="enableVoiceProcessing">Enable iOS voice processing (echo cancellation, noise reduction, AGC)</param>
+        public static AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency, bool enableVoiceProcessing)
+        {
+#if !UNITY_EDITOR
+            // Force cleanup if already recording
+            if (isCurrentlyRecording)
+            {
+                ForceReset();
+            }
+
+            string targetDevice = string.IsNullOrEmpty(deviceName) ? "Default" : deviceName;
+
+            DebugLog($"Starting recording: device={targetDevice}, length={lengthSec}s, freq={frequency}Hz, voiceProcessing={enableVoiceProcessing}");
+
+            // Call appropriate native function based on voice processing setting
+            int result = enableVoiceProcessing
+                ? iOSNativeMicrophonePlugin_StartWithVoiceProcessing(targetDevice, lengthSec, frequency, 1)
+                : iOSNativeMicrophonePlugin_Start(targetDevice, lengthSec, frequency);
+
+            if (result == 1)
+            {
+                // Create Unity AudioClip as container
+                currentClip = AudioClip.Create("MicrophoneClip", lengthSec * frequency, 1, frequency, false);
+                
+                // IMPORTANT: Set HideFlags to prevent serialization issues in Editor
+                currentClip.hideFlags = HideFlags.DontSave;
+                
+                isCurrentlyRecording = true;
+                currentDevice = targetDevice;
+                bufferSize = lengthSec * frequency;
+                sampleRate = frequency;
+                voiceProcessingEnabled = enableVoiceProcessing;
+
+                // Allocate managed buffer for audio data transfer
+                pluginAudioBuffer = new float[bufferSize];
+
+                DebugLog($"Recording started successfully. BufferSize: {bufferSize}, VoiceProcessing: {enableVoiceProcessing}");
+                return currentClip;
+            }
+            else
+            {
+                DebugLogError($"Failed to start recording. Result: {result}");
+                return null;
+            }
+#else
+            // Fallback to Unity's Microphone on non-iOS platforms
+            DebugLog("Using Unity's built-in Microphone (not on iOS device)");
+            return Microphone.Start(deviceName, loop, lengthSec, frequency);
+#endif
+        }
+
+        /// <summary>
+        /// Stop recording on specified device
+        /// </summary>
+        public static void End(string deviceName)
+        {
+#if !UNITY_EDITOR
+            if (!isCurrentlyRecording)
+                return;
+
+            // Check if we're ending the correct device
+            if (!string.IsNullOrEmpty(deviceName) && deviceName != currentDevice)
+                return;
+
+            DebugLog("Ending recording");
+            iOSNativeMicrophonePlugin_End();
+
+            // Properly destroy AudioClip
+            if (currentClip != null)
+            {
+                UnityEngine.Object.Destroy(currentClip);
+                currentClip = null;
+            }
+
+            // Clear state
+            isCurrentlyRecording = false;
+            currentDevice = null;
+            pluginAudioBuffer = null;
+            voiceProcessingEnabled = false;
+#else
+            // Fallback to Unity's Microphone
+            Microphone.End(deviceName);
+#endif
+        }
+
+        /// <summary>
+        /// Check if currently recording on specified device
+        /// </summary>
+        public static bool IsRecording(string deviceName)
+        {
+#if !UNITY_EDITOR
+            if (!isCurrentlyRecording)
+                return false;
+
+            // Check device match
+            if (!string.IsNullOrEmpty(deviceName) && deviceName != currentDevice)
+                return false;
+
+            // Verify with native plugin
+            bool pluginIsRecording = iOSNativeMicrophonePlugin_IsRecording() == 1;
+
+            if (!pluginIsRecording)
+            {
+                isCurrentlyRecording = false;
+                return false;
+            }
+
+            // Update AudioClip with latest data
+            UpdateAudioClip();
+            return true;
+#else
+            // Fallback to Unity's Microphone
+            return Microphone.IsRecording(deviceName);
+#endif
+        }
+
+        /// <summary>
+        /// Get current recording position in samples
+        /// </summary>
+        public static int GetPosition(string deviceName)
+        {
+#if !UNITY_EDITOR
+            if (!IsRecording(deviceName))
+                return 0;
+
+            return iOSNativeMicrophonePlugin_GetPosition();
+#else
+            // Fallback to Unity's Microphone
+            return Microphone.GetPosition(deviceName);
+#endif
+        }
+
+        /// <summary>
+        /// Transfer audio data from native plugin to Unity AudioClip
+        /// </summary>
+        private static void UpdateAudioClip()
+        {
+#if !UNITY_EDITOR
+            if (currentClip == null || pluginAudioBuffer == null)
+                return;
+
+            IntPtr dataPtr = iOSNativeMicrophonePlugin_GetAudioData();
+            if (dataPtr == IntPtr.Zero)
+                return;
+
+            try
+            {
+                // Copy native audio buffer to managed array
+                Marshal.Copy(dataPtr, pluginAudioBuffer, 0, bufferSize);
+
+                // Update AudioClip with new data
+                currentClip.SetData(pluginAudioBuffer, 0);
+            }
+            catch (Exception ex)
+            {
+                DebugLogError($"Error updating AudioClip: {ex.Message}");
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Force reset all recording state
+        /// </summary>
+        public static void ForceReset()
+        {
+#if !UNITY_EDITOR
+            DebugLog("Force resetting plugin state");
+
+            try
+            {
+                // Reset native plugin
+                iOSNativeMicrophonePlugin_ForceReset();
+
+                // Properly destroy AudioClip if it exists
+                if (currentClip != null)
+                {
+                    UnityEngine.Object.Destroy(currentClip);
+                    currentClip = null;
+                }
+
+                // Clear managed state
+                isCurrentlyRecording = false;
+                currentDevice = null;
+                pluginAudioBuffer = null;
+                voiceProcessingEnabled = false;
+
+                DebugLog("Plugin and Unity state reset successfully");
+            }
+            catch (Exception ex)
+            {
+                DebugLogError($"Error during force reset: {ex.Message}");
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Check if voice processing is currently enabled
+        /// </summary>
+        public static bool IsVoiceProcessingEnabled()
+        {
+            return voiceProcessingEnabled;
+        }
+
+        /// <summary>
+        /// Request microphone permission (iOS specific)
+        /// </summary>
+        public static void RequestMicrophonePermission()
+        {
+#if !UNITY_EDITOR
+            // On iOS, permission is requested automatically when starting recording
+            // This method is provided for explicit permission request if needed
+            DebugLog("Microphone permission will be requested on first recording attempt");
+            
+            // Use Unity's Application.RequestUserAuthorization for iOS
+            Application.RequestUserAuthorization(UserAuthorization.Microphone);
+            DebugLog("Requesting microphone permission...");
+#else
+            DebugLog("RequestMicrophonePermission is iOS specific");
+#endif
+        }
+
+        /// <summary>
+        /// Check if microphone permission is granted
+        /// </summary>
+        public static bool HasMicrophonePermission()
+        {
+#if !UNITY_EDITOR
+            return Application.HasUserAuthorization(UserAuthorization.Microphone);
+#else
+            return true; // Assume permission on non-iOS platforms
+#endif
+        }
+
+#if UNITY_EDITOR
+        // Unity Editor cleanup handling
+        [UnityEditor.InitializeOnLoadMethod]
+        private static void InitializeOnLoad()
+        {
+            UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(UnityEditor.PlayModeStateChange state)
+        {
+            // Clean up when exiting play mode or edit mode
+            if (state == UnityEditor.PlayModeStateChange.ExitingPlayMode ||
+                state == UnityEditor.PlayModeStateChange.ExitingEditMode)
+            {
+                try
+                {
+                    ForceReset();
+                }
+                catch (Exception ex)
+                {
+                    // Use warning instead of error for editor cleanup
+                    Debug.LogWarning($"[iOSNativeMicrophone] Cleanup warning: {ex.Message}");
+                }
+            }
+        }
+#endif
+    }
+}
+#endif

--- a/Scripts/IO/IOSNativeMicrophone.cs.meta
+++ b/Scripts/IO/IOSNativeMicrophone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b221b8e6517404eaca54d8aeaf70e47f

--- a/Scripts/IO/MacNativeMicrophone.cs
+++ b/Scripts/IO/MacNativeMicrophone.cs
@@ -1,0 +1,319 @@
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+
+using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace ChatdollKit.IO
+{
+    public static class MacNativeMicrophone
+    {
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern int MacNativeMicrophonePlugin_GetDeviceCount();
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern IntPtr MacNativeMicrophonePlugin_GetDeviceName(int index);
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern int MacNativeMicrophonePlugin_Start(string deviceName, int lengthSec, int frequency);
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern int MacNativeMicrophonePlugin_StartWithVoiceProcessing(string deviceName, int lengthSec, int frequency, int enableVoiceProcessing);
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern void MacNativeMicrophonePlugin_End();
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern int MacNativeMicrophonePlugin_IsRecording();
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern int MacNativeMicrophonePlugin_GetPosition();
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern IntPtr MacNativeMicrophonePlugin_GetAudioData();
+        [DllImport("MacNativeMicrophonePlugin")]
+        private static extern void MacNativeMicrophonePlugin_ForceReset();
+
+        private static AudioClip currentClip;
+        private static bool isCurrentlyRecording = false;
+        private static string currentDevice = null;
+        private static float[] pluginAudioBuffer;
+        private static int bufferSize;
+        private static int sampleRate;
+        private static bool voiceProcessingEnabled = false;
+
+        // Enable/disable debug logging
+        private const bool DEBUG_LOG_ENABLED = true;
+
+        private static void DebugLog(string message)
+        {
+            if (DEBUG_LOG_ENABLED)
+            {
+                Debug.Log($"[MacNativeMicrophone] {message}");
+            }
+        }
+
+        private static void DebugLogError(string message)
+        {
+            Debug.LogError($"[MacNativeMicrophone] {message}");
+        }
+
+        /// <summary>
+        /// Get all available audio input devices
+        /// </summary>
+        public static string[] devices
+        {
+            get
+            {
+                int count = MacNativeMicrophonePlugin_GetDeviceCount();
+                string[] deviceNames = new string[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    IntPtr namePtr = MacNativeMicrophonePlugin_GetDeviceName(i);
+                    deviceNames[i] = Marshal.PtrToStringAnsi(namePtr);
+                }
+
+                return deviceNames;
+            }
+        }
+
+        /// <summary>
+        /// Start recording with default voice processing enabled
+        /// </summary>
+        public static AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency)
+        {
+            return Start(deviceName, loop, lengthSec, frequency, true);
+        }
+
+        /// <summary>
+        /// Start recording with optional voice processing
+        /// </summary>
+        /// <param name="deviceName">Device name or null for default</param>
+        /// <param name="loop">Loop recording (not used in current implementation)</param>
+        /// <param name="lengthSec">Recording buffer length in seconds</param>
+        /// <param name="frequency">Sample rate in Hz</param>
+        /// <param name="enableVoiceProcessing">Enable macOS voice processing (echo cancellation, noise reduction)</param>
+        public static AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency, bool enableVoiceProcessing)
+        {
+            // Force cleanup if already recording
+            if (isCurrentlyRecording)
+            {
+                ForceReset();
+            }
+
+            string targetDevice = string.IsNullOrEmpty(deviceName) ? "Default" : deviceName;
+
+            DebugLog($"Starting recording: device={targetDevice}, length={lengthSec}s, freq={frequency}Hz, voiceProcessing={enableVoiceProcessing}");
+
+            // Call appropriate native function based on voice processing setting
+            int result = enableVoiceProcessing
+                ? MacNativeMicrophonePlugin_StartWithVoiceProcessing(targetDevice, lengthSec, frequency, 1)
+                : MacNativeMicrophonePlugin_Start(targetDevice, lengthSec, frequency);
+
+            if (result == 1)
+            {
+                // Create Unity AudioClip as container
+                currentClip = AudioClip.Create("MicrophoneClip", lengthSec * frequency, 1, frequency, false);
+                
+                // IMPORTANT: Set HideFlags to prevent serialization issues in Editor
+#if UNITY_EDITOR
+                currentClip.hideFlags = HideFlags.DontSave;
+#endif
+                
+                isCurrentlyRecording = true;
+                currentDevice = targetDevice;
+                bufferSize = lengthSec * frequency;
+                sampleRate = frequency;
+                voiceProcessingEnabled = enableVoiceProcessing;
+
+                // Allocate managed buffer for audio data transfer
+                pluginAudioBuffer = new float[bufferSize];
+
+                DebugLog($"Recording started successfully. BufferSize: {bufferSize}, VoiceProcessing: {enableVoiceProcessing}");
+                return currentClip;
+            }
+            else
+            {
+                DebugLogError($"Failed to start recording. Result: {result}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Stop recording on specified device
+        /// </summary>
+        public static void End(string deviceName)
+        {
+            if (!isCurrentlyRecording)
+                return;
+
+            // Check if we're ending the correct device
+            if (!string.IsNullOrEmpty(deviceName) && deviceName != currentDevice)
+                return;
+
+            DebugLog("Ending recording");
+            MacNativeMicrophonePlugin_End();
+
+            // Properly destroy AudioClip
+            if (currentClip != null)
+            {
+#if UNITY_EDITOR
+                if (Application.isPlaying)
+                {
+                    UnityEngine.Object.Destroy(currentClip);
+                }
+                else
+                {
+                    UnityEngine.Object.DestroyImmediate(currentClip);
+                }
+#else
+                UnityEngine.Object.Destroy(currentClip);
+#endif
+                currentClip = null;
+            }
+
+            // Clear state
+            isCurrentlyRecording = false;
+            currentDevice = null;
+            pluginAudioBuffer = null;
+            voiceProcessingEnabled = false;
+        }
+
+        /// <summary>
+        /// Check if currently recording on specified device
+        /// </summary>
+        public static bool IsRecording(string deviceName)
+        {
+            if (!isCurrentlyRecording)
+                return false;
+
+            // Check device match
+            if (!string.IsNullOrEmpty(deviceName) && deviceName != currentDevice)
+                return false;
+
+            // Verify with native plugin
+            bool pluginIsRecording = MacNativeMicrophonePlugin_IsRecording() == 1;
+
+            if (!pluginIsRecording)
+            {
+                isCurrentlyRecording = false;
+                return false;
+            }
+
+            // Update AudioClip with latest data
+            UpdateAudioClip();
+            return true;
+        }
+
+        /// <summary>
+        /// Get current recording position in samples
+        /// </summary>
+        public static int GetPosition(string deviceName)
+        {
+            if (!IsRecording(deviceName))
+                return 0;
+
+            return MacNativeMicrophonePlugin_GetPosition();
+        }
+
+        /// <summary>
+        /// Transfer audio data from native plugin to Unity AudioClip
+        /// </summary>
+        private static void UpdateAudioClip()
+        {
+            if (currentClip == null || pluginAudioBuffer == null)
+                return;
+
+            IntPtr dataPtr = MacNativeMicrophonePlugin_GetAudioData();
+            if (dataPtr == IntPtr.Zero)
+                return;
+
+            try
+            {
+                // Copy native audio buffer to managed array
+                Marshal.Copy(dataPtr, pluginAudioBuffer, 0, bufferSize);
+
+                // Update AudioClip with new data
+                currentClip.SetData(pluginAudioBuffer, 0);
+            }
+            catch (Exception ex)
+            {
+                DebugLogError($"Error updating AudioClip: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Force reset all recording state (useful for Unity Editor)
+        /// </summary>
+        public static void ForceReset()
+        {
+            DebugLog("Force resetting plugin state");
+
+            try
+            {
+                // Reset native plugin
+                MacNativeMicrophonePlugin_ForceReset();
+
+                // Properly destroy AudioClip if it exists
+                if (currentClip != null)
+                {
+#if UNITY_EDITOR
+                    if (Application.isPlaying)
+                    {
+                        UnityEngine.Object.Destroy(currentClip);
+                    }
+                    else
+                    {
+                        UnityEngine.Object.DestroyImmediate(currentClip);
+                    }
+#else
+                    UnityEngine.Object.Destroy(currentClip);
+#endif
+                    currentClip = null;
+                }
+
+                // Clear managed state
+                isCurrentlyRecording = false;
+                currentDevice = null;
+                pluginAudioBuffer = null;
+                voiceProcessingEnabled = false;
+
+                DebugLog("Plugin and Unity state reset successfully");
+            }
+            catch (Exception ex)
+            {
+                DebugLogError($"Error during force reset: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Check if voice processing is currently enabled
+        /// </summary>
+        public static bool IsVoiceProcessingEnabled()
+        {
+            return voiceProcessingEnabled;
+        }
+
+#if UNITY_EDITOR
+        // Unity Editor cleanup handling
+        [UnityEditor.InitializeOnLoadMethod]
+        private static void InitializeOnLoad()
+        {
+            UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(UnityEditor.PlayModeStateChange state)
+        {
+            // Clean up when exiting play mode or edit mode
+            if (state == UnityEditor.PlayModeStateChange.ExitingPlayMode ||
+                state == UnityEditor.PlayModeStateChange.ExitingEditMode)
+            {
+                try
+                {
+                    ForceReset();
+                }
+                catch (Exception ex)
+                {
+                    // Use warning instead of error for editor cleanup
+                    Debug.LogWarning($"[MacNativeMicrophone] Cleanup warning: {ex.Message}");
+                }
+            }
+        }
+#endif
+    }
+}
+#endif

--- a/Scripts/IO/MacNativeMicrophone.cs.meta
+++ b/Scripts/IO/MacNativeMicrophone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b109d184b4ed3490082c3f3d9d5becf8

--- a/Scripts/SpeechListener/AndroidMicrophoneProvider.cs
+++ b/Scripts/SpeechListener/AndroidMicrophoneProvider.cs
@@ -1,0 +1,19 @@
+#if UNITY_ANDROID
+
+using UnityEngine;
+using ChatdollKit.IO;
+
+namespace ChatdollKit.SpeechListener
+{
+    public class AndroidMicrophoneProvider : IMicrophoneProvider
+    {
+        public bool IsRecording(string deviceName) => AndroidNativeMicrophone.IsRecording(deviceName);
+        public AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency)
+            => AndroidNativeMicrophone.Start(deviceName, loop, lengthSec, frequency);
+        public void End(string deviceName) => AndroidNativeMicrophone.End(deviceName);
+        public int GetPosition(string deviceName) => AndroidNativeMicrophone.GetPosition(deviceName);
+        public string[] devices => AndroidNativeMicrophone.devices;
+    }
+}
+
+#endif

--- a/Scripts/SpeechListener/AndroidMicrophoneProvider.cs.meta
+++ b/Scripts/SpeechListener/AndroidMicrophoneProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c04221c1829224eb48b9a3518918c63d

--- a/Scripts/SpeechListener/IMicrophoneProvider.cs
+++ b/Scripts/SpeechListener/IMicrophoneProvider.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace ChatdollKit.SpeechListener
+{
+    public interface IMicrophoneProvider
+    {
+        bool IsRecording(string deviceName);
+        AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency);
+        void End(string deviceName);
+        int GetPosition(string deviceName);
+        string[] devices { get; }
+    }
+}

--- a/Scripts/SpeechListener/IMicrophoneProvider.cs.meta
+++ b/Scripts/SpeechListener/IMicrophoneProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce2da5d60eb0f4c3a843cf5bbd26d678

--- a/Scripts/SpeechListener/IOSMicrophoneProvider.cs
+++ b/Scripts/SpeechListener/IOSMicrophoneProvider.cs
@@ -1,0 +1,19 @@
+#if UNITY_IOS
+
+using UnityEngine;
+using ChatdollKit.IO;
+
+namespace ChatdollKit.SpeechListener
+{
+    public class IOSMicrophoneProvider : IMicrophoneProvider
+    {
+        public bool IsRecording(string deviceName) => IOSNativeMicrophone.IsRecording(deviceName);
+        public AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency)
+            => IOSNativeMicrophone.Start(deviceName, loop, lengthSec, frequency);
+        public void End(string deviceName) => IOSNativeMicrophone.End(deviceName);
+        public int GetPosition(string deviceName) => IOSNativeMicrophone.GetPosition(deviceName);
+        public string[] devices => IOSNativeMicrophone.devices;
+    }
+}
+
+#endif

--- a/Scripts/SpeechListener/IOSMicrophoneProvider.cs.meta
+++ b/Scripts/SpeechListener/IOSMicrophoneProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f82f6f7cf47264035ba8d11028fa412f

--- a/Scripts/SpeechListener/MacMicrophoneProvider.cs
+++ b/Scripts/SpeechListener/MacMicrophoneProvider.cs
@@ -1,0 +1,19 @@
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+
+using UnityEngine;
+using ChatdollKit.IO;
+
+namespace ChatdollKit.SpeechListener
+{
+    public class MacMicrophoneProvider : IMicrophoneProvider
+    {
+        public bool IsRecording(string deviceName) => MacNativeMicrophone.IsRecording(deviceName);
+        public AudioClip Start(string deviceName, bool loop, int lengthSec, int frequency)
+            => MacNativeMicrophone.Start(deviceName, loop, lengthSec, frequency);
+        public void End(string deviceName) => MacNativeMicrophone.End(deviceName);
+        public int GetPosition(string deviceName) => MacNativeMicrophone.GetPosition(deviceName);
+        public string[] devices => MacNativeMicrophone.devices;
+    }
+}
+
+#endif

--- a/Scripts/SpeechListener/MacMicrophoneProvider.cs.meta
+++ b/Scripts/SpeechListener/MacMicrophoneProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b014aba204804836ba1468fc9ef2efc


### PR DESCRIPTION
Introduced platform-specific native microphone implementations for Android, iOS, and macOSX, each with voice processing and permission handling.

Also added `IMicrophoneProvider` interface and platform-specific provider classes to abstract microphone access and updated `MicrophoneManager` to use the new provider abstraction, improving cross-platform support and maintainability.

Example:

```csharp
// Use iOS native microphone (Unity built-in on editor)
var microphoneManager = gameObject.GetComponent<MicrophoneManager>();
microphoneManager.MicrophoneProvider = new IOSMicrophoneProvider();
```