### PR TITLE
Add request merging to prevent fragmented speech recognition

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -100,6 +100,21 @@ namespace ChatdollKit.LLM.ChatGPT
 
             // Histories
             messages.AddRange(GetContext(historyTurns * 2));
+            for (var i = messages.Count - 1; i >= 0; i--)
+            {
+                if (messages[i] is ChatGPTSystemMessage) continue;
+
+                if (messages[i] is ChatGPTAssistantMessage assistantMessage
+                    && assistantMessage.content != null
+                    && assistantMessage.tool_calls == null)
+                {
+                    break;
+                }
+                else
+                {
+                    messages.RemoveAt(i);
+                }
+            }
 
             // User (current input)
             if (((Dictionary<string, object>)payloads["RequestPayloads"]).ContainsKey("imageBytes"))


### PR DESCRIPTION
- Merge multiple consecutive requests within `mergeRequestThreshold` timeframe
- Prevents conversation breakdown when user speech is recognized in fragments
- Improves conversation continuity and user experience

To enable this feature, set `mergeRequestThreshold` in `DialogProcessor` to a value greater than 0 on inspector. When a new request arrives within the specified seconds after the previous request, they will be merged into a single request.