### PR TITLE
Refactor tool call handling and context updates for LLMs

### DIFF
--- a/Scripts/Dialog/DialogProcessor.cs
+++ b/Scripts/Dialog/DialogProcessor.cs
@@ -180,21 +180,9 @@ namespace ChatdollKit.Dialog
                 }
 
                 // Call LLM
+                Status = DialogStatus.Processing;
                 var messages = await llmService.MakePromptAsync("_", text, llmPayloads, token);
                 var llmSession = await llmService.GenerateContentAsync(messages, llmPayloads, token: token);
-
-                // Tool call
-                Status = DialogStatus.Routing;
-                if (!string.IsNullOrEmpty(llmSession.FunctionName))
-                {
-                    if (toolResolver.ContainsKey(llmSession.FunctionName))
-                    {
-                        var tool = toolResolver[llmSession.FunctionName];
-                        Status = DialogStatus.Processing;
-                        llmSession = await tool.ProcessAsync(llmService, llmSession, llmPayloads, token);
-                        if (token.IsCancellationRequested) { return; }
-                    }
-                }
 
                 if (OnBeforeProcessContentStreamAsync != null)
                 {

--- a/Scripts/LLM/ILLMService.cs
+++ b/Scripts/LLM/ILLMService.cs
@@ -14,7 +14,6 @@ namespace ChatdollKit.LLM
         void ClearContext();
         UniTask<List<ILLMMessage>> MakePromptAsync(string userId, string inputText, Dictionary<string, object> payloads, CancellationToken token = default);
         UniTask<ILLMSession> GenerateContentAsync(List<ILLMMessage> messages, Dictionary<string, object> payloads = null, bool useFunctions = true, int retryCounter = 1, CancellationToken token = default);
-        ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null);
         Func<string, Dictionary<string, object>, ILLMSession, CancellationToken, UniTask> OnStreamingEnd { get; set; }
         Action <Dictionary<string, string>, ILLMSession> HandleExtractedTags { get; set; }
         Func<string, UniTask<byte[]>> CaptureImage { get; set; }
@@ -34,6 +33,7 @@ namespace ChatdollKit.LLM
         ResponseType ResponseType { get; set; }
         UniTask StreamingTask { get; set; }
         string FunctionName { get; set; }
+        string FunctionArguments { get; set; }
         List<ILLMMessage> Contexts { get; set; }
         string ContextId { get; set; }
         bool ProcessLastChunkImmediately { get; set; }

--- a/Scripts/LLM/ITool.cs
+++ b/Scripts/LLM/ITool.cs
@@ -8,5 +8,18 @@ namespace ChatdollKit.LLM
     {
         ILLMTool GetToolSpec();
         UniTask<ILLMSession> ProcessAsync(ILLMService llmService, ILLMSession llmSession, Dictionary<string, object> payloads, CancellationToken token);
+        UniTask<ToolResponse> ExecuteAsync(string argumentsJsonString, CancellationToken token);
+    }
+
+    public class ToolResponse
+    {
+        public string Body { get; protected set; }
+        public string Role { get; protected set; }
+
+        public ToolResponse(string body, string role = "function")
+        {
+            Body = body;
+            Role = role;
+        }
     }
 }

--- a/Scripts/LLM/LLMServiceBase.cs
+++ b/Scripts/LLM/LLMServiceBase.cs
@@ -40,7 +40,7 @@ namespace ChatdollKit.LLM
         public string SystemMessageContent;
         public string ErrorMessageContent;
         [SerializeField]
-        protected int historyTurns = 10;
+        protected int historyTurns = 100;
         [SerializeField]
         protected int contextTimeout = 600;    // 10 min
         protected float contextUpdatedAt;
@@ -86,11 +86,6 @@ namespace ChatdollKit.LLM
         }
 
 #pragma warning disable CS1998
-        public virtual ILLMMessage CreateMessageAfterFunction(string role = null, string content = null, ILLMSession llmSession = null, Dictionary<string, object> arguments = null)
-        {
-            throw new NotImplementedException("LLMServiceBase.CreateMessageAfterFunction must be implemented");
-        }
-
         public virtual async UniTask<List<ILLMMessage>> MakePromptAsync(string userId, string inputText, Dictionary<string, object> payloads, CancellationToken token = default)
         {
             throw new NotImplementedException("LLMServiceBase.MakePromptAsync must be implemented");
@@ -131,6 +126,7 @@ namespace ChatdollKit.LLM
         public ResponseType ResponseType { get; set; } = ResponseType.None;
         public UniTask StreamingTask { get; set; }
         public string FunctionName { get; set; }
+        public string FunctionArguments { get; set; }
         public List<ILLMMessage> Contexts { get; set; }
         public string ContextId { get; set; }
         public bool ProcessLastChunkImmediately { get; set; } = false;

--- a/Scripts/LLM/ToolBase.cs
+++ b/Scripts/LLM/ToolBase.cs
@@ -15,20 +15,14 @@ namespace ChatdollKit.LLM
 
         public async UniTask<ILLMSession> ProcessAsync(ILLMService llmService, ILLMSession llmSession, Dictionary<string, object> payloads, CancellationToken token)
         {
-            // TODO: Waiting AnimatedVoice. See https://x.com/uezochan/status/1795216169969864865
-            await llmSession.StreamingTask;
+            // Implementation for migration from older version
+            return null;
+        }
 
-            // Execute function
-            var responseForRequest = await ExecuteFunction(llmSession.StreamBuffer, token);
-
-            // Add human message for next request
-            var humanFriendlyAnswerRequestMessage = llmService.CreateMessageAfterFunction(responseForRequest.Role, responseForRequest.Body, llmSession: llmSession);
-            llmSession.Contexts.Add(humanFriendlyAnswerRequestMessage);
-
-            // Call LLM to get human-friendly response
-            var llmSessionForHuman = await llmService.GenerateContentAsync(llmSession.Contexts, payloads, false, token: token);
-
-            return llmSessionForHuman;
+        public virtual async UniTask<ToolResponse> ExecuteAsync(string argumentsJsonString, CancellationToken token)
+        {
+            // Implementation for migration from older version
+            return await ExecuteFunction(argumentsJsonString, token);
         }
 
 #pragma warning disable CS1998
@@ -37,17 +31,5 @@ namespace ChatdollKit.LLM
             throw new NotImplementedException("ToolBase.ExecuteFunction must be implemented");
         }
 #pragma warning restore CS1998
-
-        protected class ToolResponse
-        {
-            public string Body { get; protected set; }
-            public string Role { get; protected set; }
-
-            public ToolResponse(string body, string role = "function")
-            {
-                Body = body;
-                Role = role;
-            }
-        }
     }
 }


### PR DESCRIPTION
- This commit unifies and refactors tool call execution and context management across ChatGPT, Claude, and Gemini services. Tool execution is now handled directly in the streaming loop, with tool responses injected into the context and recursive streaming calls for tool use.
- The obsolete CreateMessageAfterFunction method is removed, and context update logic is improved to ensure valid tool call/response sequences.
- The ITool interface and ToolBase are updated to support direct tool execution.
- Increase default historyTurns from 10 to 100 in LLMServiceBase.