### PR TITLE
Fix recursive streaming to disable function calls

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -356,7 +356,7 @@ namespace ChatdollKit.LLM.ChatGPT
                         chatGPTSession.FunctionName = null;
                         chatGPTSession.FunctionArguments = null;
                         // Call recursively with tool response
-                        await StartStreamingAsync(chatGPTSession, customParameters, customHeaders, useFunctions, token);
+                        await StartStreamingAsync(chatGPTSession, customParameters, customHeaders, false, token);
                     }
                 }
             }

--- a/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
@@ -191,7 +191,7 @@ namespace ChatdollKit.LLM.ChatGPT
                         chatGPTSession.FunctionName = null;
                         chatGPTSession.FunctionArguments = null;
                         // Call recursively with tool response
-                        await StartStreamingAsync(chatGPTSession, customParameters, customHeaders, useFunctions, token);
+                        await StartStreamingAsync(chatGPTSession, customParameters, customHeaders, false, token);
                     }
                 }
             }

--- a/Scripts/LLM/Claude/ClaudeService.cs
+++ b/Scripts/LLM/Claude/ClaudeService.cs
@@ -301,7 +301,7 @@ namespace ChatdollKit.LLM.Claude
                         claudeSession.FunctionName = null;
                         claudeSession.FunctionArguments = null;
                         // Call recursively with tool response
-                        await StartStreamingAsync(claudeSession, customParameters, customHeaders, useFunctions, token);
+                        await StartStreamingAsync(claudeSession, customParameters, customHeaders, false, token);
                     }
                 }
             }

--- a/Scripts/LLM/Claude/ClaudeServiceWebGL.cs
+++ b/Scripts/LLM/Claude/ClaudeServiceWebGL.cs
@@ -201,7 +201,7 @@ namespace ChatdollKit.LLM.Claude
                 }
 
                 // Call recursively with image
-                await StartStreamingAsync(claudeSession, customParameters, customHeaders, useFunctions, token);
+                await StartStreamingAsync(claudeSession, customParameters, customHeaders, false, token);
             }
             else
             {

--- a/Scripts/LLM/Gemini/GeminiService.cs
+++ b/Scripts/LLM/Gemini/GeminiService.cs
@@ -328,7 +328,7 @@ namespace ChatdollKit.LLM.Gemini
                         geminiSession.FunctionName = null;
                         geminiSession.FunctionArguments = null;
                         // Call recursively with tool response
-                        await StartStreamingAsync(geminiSession, customParameters, customHeaders, useFunctions, token);
+                        await StartStreamingAsync(geminiSession, customParameters, customHeaders, false, token);
                     }
                 }
             }

--- a/Scripts/LLM/Gemini/GeminiServiceWebGL.cs
+++ b/Scripts/LLM/Gemini/GeminiServiceWebGL.cs
@@ -204,7 +204,7 @@ namespace ChatdollKit.LLM.Gemini
                 }
 
                 // Call recursively with image
-                await StartStreamingAsync(geminiSession, customParameters, customHeaders, useFunctions, token);
+                await StartStreamingAsync(geminiSession, customParameters, customHeaders, false, token);
             }
             else
             {


### PR DESCRIPTION
Updated recursive calls to `StartStreamingAsync` in ChatGPT, Claude, and Gemini service classes to always pass 'false' for the useFunctions parameter. This prevents unintended function calls during recursive streaming after a tool or image response.