### PR TITLE
Mask tools when function calling is disabled

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -194,7 +194,7 @@ namespace ChatdollKit.LLM.ChatGPT
             {
                 data.Add("max_tokens", MaxTokens);
             }
-            if (useFunctions && Tools.Count > 0 && !Model.ToLower().Contains("vision"))
+            if (Tools.Count > 0)
             {
                 var tools = new List<Dictionary<string, object>>();
                 foreach (var tool in Tools)
@@ -206,6 +206,11 @@ namespace ChatdollKit.LLM.ChatGPT
                     });
                 }
                 data.Add("tools", tools);
+                // Mask tools if useFunctions = false. Don't remove tools to keep cache hit and to prevent hallucination
+                if (!useFunctions)
+                {
+                    data.Add("tool_choice", "none");
+                }
             }
             if (Logprobs == true)
             {

--- a/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTServiceWebGL.cs
@@ -62,7 +62,7 @@ namespace ChatdollKit.LLM.ChatGPT
             {
                 data.Add("max_tokens", MaxTokens);
             }
-            if (useFunctions && Tools.Count > 0)
+            if (Tools.Count > 0)
             {
                 var tools = new List<Dictionary<string, object>>();
                 foreach (var tool in Tools)
@@ -74,6 +74,11 @@ namespace ChatdollKit.LLM.ChatGPT
                     });
                 }
                 data.Add("tools", tools);
+                // Mask tools if useFunctions = false. Don't remove tools to keep cache hit and to prevent hallucination
+                if (!useFunctions)
+                {
+                    data.Add("tool_choice", "none");
+                }
             }
             if (Logprobs == true)
             {

--- a/Scripts/LLM/Claude/ClaudeService.cs
+++ b/Scripts/LLM/Claude/ClaudeService.cs
@@ -164,6 +164,11 @@ namespace ChatdollKit.LLM.Claude
                     claudeTools.Add(new ClaudeTool(tool));
                 }
                 data.Add("tools", claudeTools);
+                // Mask tools if useFunctions = false. Don't remove tools to prevent hallucination
+                if (!useFunctions)
+                {
+                    data.Add("tool_choice", new Dictionary<string, string>(){ {"type", "none"} });
+                }
             }
 
             if (TopK > 0)

--- a/Scripts/LLM/Claude/ClaudeServiceWebGL.cs
+++ b/Scripts/LLM/Claude/ClaudeServiceWebGL.cs
@@ -60,6 +60,11 @@ namespace ChatdollKit.LLM.Claude
                     claudeTools.Add(new ClaudeTool(tool));
                 }
                 data.Add("tools", claudeTools);
+                // Mask tools if useFunctions = false. Don't remove tools to prevent hallucination
+                if (!useFunctions)
+                {
+                    data.Add("tool_choice", new Dictionary<string, string>(){ {"type", "none"} });
+                }
             }
 
             if (TopK > 0)

--- a/Scripts/LLM/Gemini/GeminiService.cs
+++ b/Scripts/LLM/Gemini/GeminiService.cs
@@ -190,14 +190,22 @@ namespace ChatdollKit.LLM.Gemini
                 data[p.Key] = p.Value;
             }
 
-            // Set tools. Multimodal model doesn't support function calling for now (2023.12.29)
-            if (useFunctions && Tools.Count > 0 && !Model.ToLower().Contains("vision"))
+            // Set tools
+            if (Tools.Count > 0)
             {
-                 data.Add("tools", new List<Dictionary<string, object>>(){
-                     new Dictionary<string, object> {
-                         { "function_declarations", Tools }
-                     }
-                 });
+                data.Add("tools", new List<Dictionary<string, object>>(){
+                    new Dictionary<string, object> {
+                        { "functionDeclarations", Tools }
+                    }
+                });
+                // Mask tools if useFunctions = false. Don't remove tools to keep cache hit and to prevent hallucination
+                if (!useFunctions)
+                {
+                    data.Add("toolConfig", new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        { "functionCallingConfig", new() { { "mode", "NONE" } } }
+                    });
+                }
             }
 
             // Prepare API request

--- a/Scripts/LLM/Gemini/GeminiServiceWebGL.cs
+++ b/Scripts/LLM/Gemini/GeminiServiceWebGL.cs
@@ -66,14 +66,22 @@ namespace ChatdollKit.LLM.Gemini
                 Debug.LogWarning("Custom headers for Gemini on WebGL is not supported for now.");
             }
 
-            // Set tools. Multimodal model doesn't support function calling for now (2023.12.29)
-            if (useFunctions && Tools.Count > 0 && !Model.ToLower().Contains("vision"))
+            // Set tools
+            if (Tools.Count > 0)
             {
                 data.Add("tools", new List<Dictionary<string, object>>(){
-                     new Dictionary<string, object> {
-                         { "function_declarations", Tools }
-                     }
-                 });
+                    new Dictionary<string, object> {
+                        { "functionDeclarations", Tools }
+                    }
+                });
+                // Mask tools if useFunctions = false. Don't remove tools to keep cache hit and to prevent hallucination
+                if (!useFunctions)
+                {
+                    data.Add("toolConfig", new Dictionary<string, Dictionary<string, string>>()
+                    {
+                        { "functionCallingConfig", new() { { "mode", "NONE" } } }
+                    });
+                }
             }
 
             var serializedData = JsonConvert.SerializeObject(data);


### PR DESCRIPTION
Updated ChatGPT, Claude, and Gemini service classes to mask tools by setting the appropriate tool choice or config when useFunctions is false, instead of removing tools from the request. This approach maintains cache hits and helps prevent hallucination, while ensuring tools are not actually invoked if function calling is disabled.