### PR TITLE
Make OnDestroy method virtual in SpeechListenerBase

### DIFF
--- a/Scripts/SpeechListener/SpeechListenerBase.cs
+++ b/Scripts/SpeechListener/SpeechListenerBase.cs
@@ -190,7 +190,7 @@ namespace ChatdollKit.SpeechListener
             Array.Copy(BitConverter.GetBytes((UInt32)(pcm.Length - 44)), 0, pcm, 40, 4);
         }
 
-        protected void OnDestroy()
+        protected virtual void OnDestroy()
         {
             if (cancellationTokenSource != null)
             {


### PR DESCRIPTION
Changed the OnDestroy method from protected to protected virtual to allow derived classes to override it if needed.