### PR TITLE
Add WebGL camera device support and refactor SimpleCamera

### DIFF
--- a/Plugins/SimpleCameraWebGL.jslib
+++ b/Plugins/SimpleCameraWebGL.jslib
@@ -1,0 +1,29 @@
+mergeInto(LibraryManager.library, {
+    GetCameraDevices: function(targetObjectNamePtr, targetFunctionNamePtr) {
+        let targetObjectName = UTF8ToString(targetObjectNamePtr);
+        let targetFunctionName = UTF8ToString(targetFunctionNamePtr);
+
+        async function getCameraNames() {
+            try {
+                const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+                stream.getTracks().forEach(track => track.stop());
+            
+                const devices = await navigator.mediaDevices.enumerateDevices();
+                const cameras = devices.filter(device => device.kind === "videoinput");
+                const cameraNames = [];
+                for (const camera of cameras) {
+                    if (camera.label) {
+                        cameraNames.push(camera.label);
+                    }
+                }
+                SendMessage(targetObjectName, targetFunctionName, JSON.stringify({names: cameraNames}));
+            
+            } catch (error) {
+                console.error("Error at GetCameraDevices", error);
+                return [];
+            }
+        }
+
+        getCameraNames();
+    }
+});

--- a/Plugins/SimpleCameraWebGL.jslib.meta
+++ b/Plugins/SimpleCameraWebGL.jslib.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a1086bceaa754b96b54b185b59ffcb3


### PR DESCRIPTION
Introduced a new SimpleCameraWebGL.jslib plugin to enumerate camera devices in WebGL builds. Refactored SimpleCamera.cs to support device loading and selection on WebGL, added device info abstraction, improved aspect ratio handling, and enhanced still image management. These changes enable cross-platform camera device enumeration and improve camera usability in Unity WebGL projects.