### PR TITLE
Add WebGL file upload support to ImageButton

### DIFF
--- a/Plugins/WebGL.meta
+++ b/Plugins/WebGL.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dba8ead01136643ea86cec48efead4a8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Plugins/WebGL/FileUploader.jslib
+++ b/Plugins/WebGL/FileUploader.jslib
@@ -1,0 +1,67 @@
+mergeInto(LibraryManager.library, {
+    OpenFileDialog: function(gameObjectNamePtr, methodNamePtr, acceptPtr) {
+        let gameObjectName = UTF8ToString(gameObjectNamePtr);
+        let methodName = UTF8ToString(methodNamePtr);
+        let accept = UTF8ToString(acceptPtr);
+
+        let fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = accept || 'image/*';
+
+        fileInput.onchange = function(event) {
+            let file = event.target.files[0];
+            if (!file) return;
+            
+            let reader = new FileReader();
+            reader.onload = function(e) {
+                let img = new Image();
+                img.onload = function() {
+                    // Resize not to exceed the max callback size
+                    let maxSize = 640;
+                    let width = img.width;
+                    let height = img.height;
+                    let scale = 1;
+                    
+                    // Calculate size
+                    if (width > height) {
+                        if (width > maxSize) {
+                            scale = maxSize / width;
+                        }
+                    } else {
+                        if (height > maxSize) {
+                            scale = maxSize / height;
+                        }
+                    }
+                    
+                    let newWidth = Math.floor(width * scale);
+                    let newHeight = Math.floor(height * scale);
+                    
+                    // Resize on canvas
+                    let canvas = document.createElement('canvas');
+                    canvas.width = newWidth;
+                    canvas.height = newHeight;
+                    let ctx = canvas.getContext('2d');
+                    ctx.drawImage(img, 0, 0, newWidth, newHeight);
+                    
+                    // Convert to ArrayBuffer
+                    canvas.toBlob(function(blob) {
+                        let blobReader = new FileReader();
+                        blobReader.onload = function(e) {
+                            let arrayBuffer = e.target.result;
+                            let bytes = new Uint8Array(arrayBuffer);
+                            
+                            let base64 = btoa(String.fromCharCode.apply(null, bytes));
+                            
+                            SendMessage(gameObjectName, methodName, base64);
+                        };
+                        blobReader.readAsArrayBuffer(blob);
+                    }, 'image/jpeg', 0.9);
+                };
+                img.src = URL.createObjectURL(file);
+            };
+            reader.readAsArrayBuffer(file);
+        };
+        
+        fileInput.click();
+    }
+});

--- a/Plugins/WebGL/FileUploader.jslib.meta
+++ b/Plugins/WebGL/FileUploader.jslib.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ada8cdfccc9d416696cc0df6452fcd1

--- a/Scripts/UI/ImageButton.cs
+++ b/Scripts/UI/ImageButton.cs
@@ -2,11 +2,19 @@ using System;
 using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
+#if UNITY_WEBGL && !UNITY_EDITOR
+using System.Runtime.InteropServices;
+#endif
 
 namespace ChatdollKit.UI
 {
     public class ImageButton : MonoBehaviour
     {
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern void OpenFileDialog(string gameObjectName, string methodName, string accept);
+#endif
+
         [SerializeField]
         private bool pathMode;
         [SerializeField]
@@ -19,6 +27,9 @@ namespace ChatdollKit.UI
 
         public void OnButtonClick()
         {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            OpenFileDialog(gameObject.name, "OnFileSelected", "image/*");
+#else
             if (pathMode)
             {
                 var active = !pathPanel.activeSelf;
@@ -33,6 +44,7 @@ namespace ChatdollKit.UI
             {
                 OnButtonClickAction();
             }
+#endif
         }
 
         public void OnSubmitImagePath()
@@ -49,5 +61,13 @@ namespace ChatdollKit.UI
             pathInput.text = string.Empty;
             pathPanel.SetActive(false);
         }
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        public void OnFileSelected(string base64Data)
+        {
+            var imageBytes = Convert.FromBase64String(base64Data);
+            HandleImage?.Invoke(imageBytes);
+        }
+#endif
     }
 }

--- a/Scripts/UI/UIControlContainer.cs
+++ b/Scripts/UI/UIControlContainer.cs
@@ -22,7 +22,7 @@ namespace ChatdollKit.UI
                 }
             }
 
-            if (imageButton.HandleImage == null)
+            if (imageButton != null && imageButton.HandleImage == null)
             {
                 imageButton.HandleImage = (imageBytes) =>
                 {


### PR DESCRIPTION
Introduced a JavaScript plugin (FileUploader.jslib) for WebGL builds to enable image file selection and resizing via a browser file dialog. Updated ImageButton.cs to use the new plugin when running in WebGL, allowing users to upload images directly.

NOTE: This feature doesn't work in Safari on Mac. We also modified `UIControlContainer` so that removing the ImageButton no longer causes errors.