### PR TITLE
Allow enabling or disabling each tool via the Inspector

### DIFF
--- a/Scripts/Dialog/DialogProcessor.cs
+++ b/Scripts/Dialog/DialogProcessor.cs
@@ -111,9 +111,12 @@ namespace ChatdollKit.Dialog
             toolSpecs.Clear();
             foreach (var tool in gameObject.GetComponents<ITool>())
             {
-                var toolSpec = tool.GetToolSpec();
-                toolResolver.Add(toolSpec.name, tool);
-                toolSpecs.Add(toolSpec);
+                if (tool.IsEnabled)
+                {
+                    var toolSpec = tool.GetToolSpec();
+                    toolResolver.Add(toolSpec.name, tool);
+                    toolSpecs.Add(toolSpec);
+                }
             }            
         }
 

--- a/Scripts/LLM/ITool.cs
+++ b/Scripts/LLM/ITool.cs
@@ -6,6 +6,7 @@ namespace ChatdollKit.LLM
 {
     public interface ITool
     {
+        bool IsEnabled { get; set; }
         ILLMTool GetToolSpec();
         UniTask<ILLMSession> ProcessAsync(ILLMService llmService, ILLMSession llmSession, Dictionary<string, object> payloads, CancellationToken token);
         UniTask<ToolResponse> ExecuteAsync(string argumentsJsonString, CancellationToken token);

--- a/Scripts/LLM/ToolBase.cs
+++ b/Scripts/LLM/ToolBase.cs
@@ -8,6 +8,17 @@ namespace ChatdollKit.LLM
 {
     public class ToolBase : MonoBehaviour, ITool
     {
+        public bool _IsEnabled = true;
+        public bool IsEnabled {
+            get {
+                return _IsEnabled;
+            }
+            set
+            {
+                _IsEnabled = value;
+            }
+        }
+
         public virtual ILLMTool GetToolSpec()
         {
             throw new NotImplementedException("ToolBase.GetToolSpec must be implemented");


### PR DESCRIPTION
Added `IsEnabled` property to the `ITool` interface. Only tools with the checkbox enabled in the Inspector will be used. This update makes it easier to test and compare behaviors with and without specific tools enabled.