### PR TITLE
Add null checks for Authorization header in API requests

### DIFF
--- a/Scripts/SpeechListener/AIAvatarKitSpeechListener.cs
+++ b/Scripts/SpeechListener/AIAvatarKitSpeechListener.cs
@@ -22,7 +22,10 @@ namespace ChatdollKit.SpeechListener
 
             using (UnityWebRequest request = UnityWebRequest.Post(EndpointUrl, form))
             {
-                request.SetRequestHeader("Authorization", $"Bearer {ApiKey}");
+                if (!string.IsNullOrEmpty(ApiKey))
+                {
+                    request.SetRequestHeader("Authorization", $"Bearer {ApiKey}");
+                }
 
                 try
                 {

--- a/Scripts/SpeechSynthesizer/AIAvatarKitSpeechSynthesizer.cs
+++ b/Scripts/SpeechSynthesizer/AIAvatarKitSpeechSynthesizer.cs
@@ -107,7 +107,10 @@ namespace ChatdollKit.SpeechSynthesizer
                 www.method = "POST";
 
                 www.SetRequestHeader("Content-Type", headers["Content-Type"]);
-                www.SetRequestHeader("Authorization", headers["Authorization"]);
+                if (headers.ContainsKey("Authorization"))
+                {
+                    www.SetRequestHeader("Authorization", headers["Authorization"]);
+                }
 
                 www.uploadHandler = new UploadHandlerRaw(data);
 


### PR DESCRIPTION
Updated both AIAvatarKitSpeechListener and AIAvatarKitSpeechSynthesizer to set the Authorization header only if the API key or header is present. This prevents sending empty or invalid Authorization headers in requests.