### PR TITLE
Add barge-in support to interrupt AI speech by user voice

### DIFF
--- a/Scripts/SpeechListener/DummySpeechListener.cs
+++ b/Scripts/SpeechListener/DummySpeechListener.cs
@@ -21,6 +21,8 @@ namespace ChatdollKit.SpeechListener
         }
 
         public Func<string, UniTask> OnRecognized { get; set; }
+        public Action OnBargeIn { get; set; }
+        public Func<string, float, bool> BargeInCondition { get; set; }
         public bool IsRecording { get; }
         public bool IsVoiceDetected { get; }
         public void ChangeSessionConfig(float silenceDurationThreshold = float.MinValue, float minRecordingDuration = float.MinValue, float maxRecordingDuration = float.MinValue)

--- a/Scripts/SpeechListener/ISpeechListener.cs
+++ b/Scripts/SpeechListener/ISpeechListener.cs
@@ -7,6 +7,8 @@ namespace ChatdollKit.SpeechListener
     {
         bool IsEnabled { get; set; }
         Func<string, UniTask> OnRecognized { get; set; }
+        Action OnBargeIn { get; set; }
+        Func<string, float, bool> BargeInCondition { get; set; }
         bool IsRecording{ get; }
         bool IsVoiceDetected { get; }
         void StartListening(bool stopBeforeStart = false);

--- a/Scripts/SpeechListener/RecordingSession.cs
+++ b/Scripts/SpeechListener/RecordingSession.cs
@@ -20,6 +20,7 @@ namespace ChatdollKit.SpeechListener
         private int prerollCount = 0;
         public bool IsRecording { get; private set; }
         public bool IsSilent { get; private set; }
+        public float RecordDuration => IsRecording ? Time.time - recordingStartTime : 0f;
         private bool isCompleted = false;
         private float silenceDuration = 0.0f;
         private float recordingStartTime;


### PR DESCRIPTION
Enable users to interrupt AI speech by speaking (barge-in). Trigger conditions are customizable via `BargeInCondition` delegate.