### PR TITLE
Add thinkingConfig field to Gemini requests

### DIFF
--- a/Scripts/LLM/Gemini/GeminiService.cs
+++ b/Scripts/LLM/Gemini/GeminiService.cs
@@ -176,7 +176,8 @@ namespace ChatdollKit.LLM.Gemini
                 topP = TopP,
                 topK = TopK,
                 maxOutputTokens = MaxOutputTokens,
-                stopSequences = StopSequences
+                stopSequences = StopSequences,
+                thinkingConfig = new() {{ "thinkingLevel", "minimal" }}
             };
 
             // Make request data
@@ -594,6 +595,7 @@ namespace ChatdollKit.LLM.Gemini
         {
             return stopSequences != null && stopSequences.Count > 0;
         }
+        public Dictionary<string, string> thinkingConfig { get; set; }
     }
 
     // Tool


### PR DESCRIPTION
Expose a thinkingConfig dictionary on the Gemini request model and initialize it when building the request (sets "thinkingLevel" to "minimal"). This enables configuring the model's thinking behavior via the request payload.