### PR TITLE
Add OpenClaw support for ChatGPTService

### DIFF
--- a/Scripts/LLM/ChatGPT/ChatGPTService.cs
+++ b/Scripts/LLM/ChatGPT/ChatGPTService.cs
@@ -32,6 +32,8 @@ namespace ChatdollKit.LLM.ChatGPT
         [SerializeField]
         protected float noDataResponseTimeoutSec = 5.0f;
 
+        public Action<UnityWebRequest, Dictionary<string, object>> EditChatCompletionRequest;
+
         protected JsonSerializerSettings messageSerializationSettings = new JsonSerializerSettings
         {
             TypeNameHandling = TypeNameHandling.All
@@ -246,6 +248,9 @@ namespace ChatdollKit.LLM.ChatGPT
             {
                 streamRequest.SetRequestHeader(h.Key, h.Value);
             }
+
+            // Edit request headers and data
+            EditChatCompletionRequest?.Invoke(streamRequest, data);
 
             if (DebugMode)
             {


### PR DESCRIPTION
Add `EditChatCompletionRequest` delegate to `ChatGPTService` that allows customizing request headers and body before sending API calls. This enables integration with OpenClaw and other OpenAI-compatible services.