### PR TITLE
Fix AbortController reuse bug in WebGL

### DIFF
--- a/Plugins/AIAvatarKitServiceWebGL.jslib
+++ b/Plugins/AIAvatarKitServiceWebGL.jslib
@@ -52,5 +52,6 @@ mergeInto(LibraryManager.library, {
     AbortAIAvatarKitMessageStreamJS: function() {
         console.log("Abort AIAvatarKit at AbortAIAvatarKitMessageStreamJS");
         document.aakAbortController.abort();
+        document.aakAbortController = null;
     }
 });

--- a/Plugins/ChatGPTServiceWebGL.jslib
+++ b/Plugins/ChatGPTServiceWebGL.jslib
@@ -52,5 +52,6 @@ mergeInto(LibraryManager.library, {
     AbortChatCompletionJS: function() {
         console.log("Abort ChatGPT at AbortChatCompletionJS");
         document.chatGPTAbortController.abort();
+        document.chatGPTAbortController = null;
     }
 });

--- a/Plugins/ClaudeServiceWebGL.jslib
+++ b/Plugins/ClaudeServiceWebGL.jslib
@@ -54,5 +54,6 @@ mergeInto(LibraryManager.library, {
     AbortClaudeMessageStreamJS: function() {
         console.log("Abort Claude at AbortClaudeMessageStreamJS");
         document.claudeAbortController.abort();
+        document.claudeAbortController = null;
     }
 });

--- a/Plugins/DifyServiceWebGL.jslib
+++ b/Plugins/DifyServiceWebGL.jslib
@@ -52,5 +52,6 @@ mergeInto(LibraryManager.library, {
     AbortDifyMessageStreamJS: function() {
         console.log("Abort Dify at AbortDifyMessageStreamJS");
         document.difyAbortController.abort();
+        document.difyAbortController = null;
     }
 });

--- a/Plugins/GeminiServiceWebGL.jslib
+++ b/Plugins/GeminiServiceWebGL.jslib
@@ -50,5 +50,6 @@ mergeInto(LibraryManager.library, {
     AbortGeminiMessageStreamJS: function() {
         console.log("Abort Gemini at AbortGeminiMessageStreamJS");
         document.geminiAbortController.abort();
+        document.geminiAbortController = null;
     }
 });


### PR DESCRIPTION
Reset `AbortController` to null after `abort()` to prevent subsequent fetch requests from being silently rejected by the already-aborted signal.